### PR TITLE
Import relevant files from Zanata.

### DIFF
--- a/master/ca.po
+++ b/master/ca.po
@@ -1,0 +1,293 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
+# Ding-Yi Chen <dingyichen@gmail.com>, 2015. #zanata
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2015-09-29 07:30-0400\n"
+"Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
+"Language-Team: Catalan (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/ca/)\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"l'opció de muntatge '%(mount_option)s' va afegir-se al punt de muntatge "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assegureu-vos de crear una contrasenya amb una mida mínima de %d caràcters"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no es pot comprovar la mida de la contrasenya de root (la contrasenya està "
+"xifrada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets instal·lats"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets exclosos"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "PERFIL DE _SEGURETAT"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "No està llest"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "S'estan obtenint les dades del contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "No s'ha seleccionat cap perfil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Sense regles per a la fase de pre-instal·lació"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"S'ha proporcionat un context no vàlid. Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"L'obtenció del contingut ha fallat. Si us plau, introduïu un URL diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"L'extracció del contingut ha fallat (%s). Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Sense aplicar la política de seguretat"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"A continuació introduïu el contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No s'ha trobat cap contingut. Si us plau, a continuació introduïu el "
+"contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "No s'ha trobat cap contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "S'ha detectat una configuració errònia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Advertències que van aparèixer"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Tot està bé"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "L'URL no és vàlid o no està admès"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "S'està obtenint el contingut..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURETAT"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Canvia el contingut"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplica la política de seguretat:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de dades:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Llista de comprovació:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Trieu el perfil a sota:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionat"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecciona el perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Els canvis que es van fer o s'han de fer:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utilitza la guia de seguretat SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Obté"

--- a/master/cs.po
+++ b/master/cs.po
@@ -1,0 +1,293 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# vpodzime <vpodzime@redhat.com>, 2014-2015
+# Zdenek <chmelarz@gmail.com>, 2016. #zanata
+# Daniel Rusek <mail@asciiwolf.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2018-10-23 10:58-0400\n"
+"Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
+"Language-Team: Czech (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/cs/)\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musí být na samostatném diskovém nebo logickém oddílu a musí být "
+"vytvořen v rozdělení oddílů předtím, než bude moci být zahájena instalace s "
+"bezpečnostním profilem"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "parametr '%(mount_option)s' přidán pro přípojný bod %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "ujistěte se, že heslo bude mít minimální délku %d znaků"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "nelze zkontrolovat délku hesla uživatele root (heslo je šifrováno)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"heslo uživatele root je příliš krátké, je vyžadováno delší heslo s nejméně "
+"%d znaky"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "balík '%s' byl přidán do seznamu instalovaných balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "balík '%s' byl přidán do seznamu vyloučených balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port '%s' byl přidán na seznam portů k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "důvěra '%s' byla přidána na seznam důvěr k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k odebrání z firewallu"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Při získávání a načítání bezpečnostních dat došlo k chybě:\n"
+"%s\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Test integrity bezpečnostních dat neprošel.\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_POLITIKA ZABEZPEČENÍ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Není připraven"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Načítají se data"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Není vybrán žádný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Žádná pravidla pro předinstalační fázi"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Nevalidní data. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Nevalidní nebo nepodporované datové URL, zadejte prosím jiné."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Načítání dat selhalo. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Během získávání dat se vyskytla chyba sítě. Zkontrolujte prosím, že je síť "
+"nastavena a funkční."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Test integrity dat neprošel. Nelze použít tato data."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Rozbalování dat selhalo (%s). Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "Profil s ID '%s' není definován v datech. Vyberte prosím jiný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Neaplikovat bezpečnostní politiku"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "nebo zadejte URL data streamu, případně archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenalezen žádný zdroj dat. Prosím uveďte URL k data streamu nebo archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Chyba při získávání a načítání dat"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Žádná data k dispozici"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Detekována nesprávná konfigurace"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Varování"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Vše v pořádku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Nevalidní nebo nepodporované URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Načítám data..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIKA ZABEZPEČENÍ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Jiná data"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplikovat bezpečnostní politiku:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Data stream:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Vyberte profil:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Vybrán"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Vybrat profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Změny, které byly nebo musejí být provedeny:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Použít SCAP Security Guide"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Načíst"

--- a/master/de.po
+++ b/master/de.po
@@ -1,0 +1,311 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:14-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} muss sich auf einer separaten Partition oder einem logischen Volume "
+"befinden und muss im Partitionslayout erstellt werden, bevor die "
+"Installation mit einem Sicherheitsprofil erfolgen kann"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"Einhängeoption '%(mount_option)s'hinzugefügt für den Einhängepunkt "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Stellen Sie sicher, dass Sie ein Kennwort mit einer Mindestlänge von "
+"erstellen %d Zeichen"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Länge des Root-Passworts kann nicht geprüft werden (Passwort wird "
+"verschlüsselt)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"Das root-Passwort ist zu kurz, ein längeres mit mindestens %d Zeichen sind "
+"erforderlich"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "Paket \"%s'wurde der Liste der zu installierenden Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "Paket \"%s'wurde der Liste der ausgeschlossenen Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Die Firewall wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Die Firewall wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die zur Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"Hafen '%s'wurde der Liste der Ports hinzugefügt, die der Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"vertrauen '%s'wurde der Liste der Vertrauensstellungen hinzugefügt, die der "
+"Firewall hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die aus der Firewall "
+"entfernt werden sollen"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Beim Abrufen und Laden des Sicherheitsinhalts ist ein Fehler "
+"aufgetreten:%sDie Installation sollte abgebrochen werden. Möchten Sie "
+"trotzdem fortfahren?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Die Integritätsprüfung des Sicherheitsinhalts ist fehlgeschlagen. Die "
+"Installation sollte abgebrochen werden. Möchten Sie trotzdem fortfahren?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_SICHERHEITSPOLITIK"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Nicht bereit"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Inhaltsdaten abrufen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Kein Profil ausgewählt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Keine Regeln für die Vorinstallationsphase"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Ungültiger Inhalt bereitgestellt Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Ungültige oder nicht unterstützte Inhalts-URL. Bitte geben Sie eine andere "
+"URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht abgerufen werden. Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Beim Abrufen von Daten ist ein Netzwerkfehler aufgetreten. Bitte überprüfen "
+"Sie, ob das Netzwerk eingerichtet ist und funktioniert."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Die Integritätsprüfung des Inhalts ist fehlgeschlagen. Der Inhalt kann nicht"
+" verwendet werden."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht extrahiert werden (%s). Bitte geben Sie eine andere URL "
+"ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profil mit ID '%s'im Inhalt nicht definiert. Bitte wählen Sie ein anderes "
+"Profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Keine Sicherheitsrichtlinie anwenden"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr " oder geben Sie den Datenstrominhalt oder die Archiv-URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Kein Inhalt gefunden Bitte geben Sie den Datenstrom-Inhalt oder die Archiv-"
+"URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Fehler beim Abrufen und Laden von Inhalten"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Kein Inhalt gefunden"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Fehlkonfiguration erkannt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Warnungen erschienen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Alles okay"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Ungültige oder nicht unterstützte URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Inhalt wird abgerufen ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "SICHERHEITSPOLITIK"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Ändern Sie den Inhalt"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Sicherheitsrichtlinie anwenden:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Datenstrom:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checkliste:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Wählen Sie unten ein Profil:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Ausgewählt"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wähle Profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Änderungen, die vorgenommen wurden oder durchgeführt werden müssen:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Verwenden Sie das SCAP-Sicherheitshandbuch"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Fetch"

--- a/master/es.po
+++ b/master/es.po
@@ -1,0 +1,316 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Gerardo Rosales <grosale86@gmail.com>, 2014
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2016. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:16-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} debe estar en una partición separada o en un volumen lógico y debe "
+"crearse en el diseño de particiones antes de que se inicie la instalación "
+"con un perfil de seguridad"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opciones de montaje '%(mount_option)s' añadidas para el punto de montaje "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Asegúrese de crear una contraseña con una longitud mínima de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no se puede comprobar la longitud de la contraseña raíz(la contraseña está "
+"encriptada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la contraseña de root es demasiado corta, se exige una más larga con al "
+"menos %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes a instalar"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes excluidos"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Se desactivará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Se activará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Se desactivará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Se activará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a añadir al "
+"cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"el puerto '%s' se ha añadido a la lista de puertos a añadir al cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"confiar%s'se ha agregado a la lista de fideicomisos que se agregarán al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a quitar del "
+"cortafuegos"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Se produjo un error al obtener y cargar el contenido de seguridad:\n"
+"%s\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Falló la comprobación de integridad del contenido de seguridad.\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_POLÍTICA DE SEGURIDAD"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "No está listo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Obteniendo datos de contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Ningún perfil seleccionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Ninguna regla para la fase de pre-instalación"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Contenido proporcionado inválido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"La URL del contenido no es válida o no está admitida, por favor introduzca "
+"una nueva."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Falló la obtención de contenido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Se produjo un error de red al obtener los datos. Compruebe que la red está "
+"configurada y en funcionamiento."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Falló la comprobación de la integridad del contenido. No se puede usar el "
+"mismo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Fallo al extraer el contenido(%s). Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"El perfil con ID '%s' no está definido en el contenido. Elija uno diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "No se aplica política de seguridad"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"o ingrese el contenido de flujo de datos o archivo URL a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No se encontró contenido. Por favor ingrese un contenido de flujo de datos o"
+" un archivo a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Error al obtener y cargar el contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "No se encontró contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Configuración errónea detectada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Advertencias aparecieron"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Todo está bien"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "URL no soportada o es inválida"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Obteniendo contenido..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURIDAD"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambiando contenido"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicando política de seguridad:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flujo de datos:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista de comprobación:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Elija un perfil a continuación:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleccionar perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Cambios que fueron o serán hechos:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usar Guía de seguridad SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Obtener"

--- a/master/fr.po
+++ b/master/fr.po
@@ -1,0 +1,314 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# dominique bribanick <chepioq@gmail.com>, 2014
+# Jérôme Fenal <jfenal@gmail.com>, 2014
+# Jean-Baptiste Holcroft <jean-baptiste@holcroft.fr>, 2016. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:08-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/fr/)\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} doit être sur une partition ou un volume logique séparé et doit être "
+"créé dans la structure de partitionnement avant que l'installation puisse "
+"avoir lieu avec un profil de sécurité."
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"option de montage « %(mount_option)s » ajoutée au point de montage "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assurez-vous de créer un mot de passe d'une longueur minimale de %d "
+"caractères"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossible de vérifier la longueur du mot de passe de root (mot de passe "
+"chiffré)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"le mot de passe de root est trop court, une longueur d'au moins %d "
+"caractères est requise"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à installer"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à exclure"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Le pare-feu va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Le pare-feu va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"trust « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à retirer du pare-feu"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il y a eu une erreur lors de l'extraction et du chargement du contenu de sécurité :\n"
+"%s\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Le contrôle d'intégrité du contenu de sécurité a échoué.\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_POLITIQUE DE SÉCURITÉ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Pas prêt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Récupération des données de contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Aucun profil sélectionné"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Aucune règle pour la phase de pré-installation"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenu fourni invalide. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL de contenu non prise en charge ou non valide, veuillez saisir une URL "
+"différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Échec de la récupération du contenu. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Erreur de réseau lors de l'extraction des données. Veuillez vérifier que le "
+"réseau ait été installé et fonctionne correctement."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Le contrôle d'intégrité du contenu a échoué. Impossible d'utiliser le "
+"contenu."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossible d'extraire le contenu (%s). Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Le profil ayant pour ID « %s »n'est pas défini dans le contenu. Sélectionner"
+" un autre profil, s'il vous plaît."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "N'applique pas la politique de sécurité"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"ou saisir un flux de données de contenu ou l'URL d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Contenu introuvable. Merci de saisir un flux de données de contenu ou l'URL "
+"d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Erreur d'extraction et de chargement du contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Contenu introuvable"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Mauvaise configuration détectée"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Des avertissements sont apparus"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Tout est OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "URL invalide ou non prise en charge"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Récupération du contenu..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIQUE DE SÉCURITÉ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Modifier le contenu"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Application des politiques de sécurité :"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de données :"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Liste de vérifications :"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Choisir le profil ci-dessous :"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Sélectionné"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Sélectionner le profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifications réalisées ou à faire :"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utiliser le guide de sécurité SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Récupérer"

--- a/master/hu.po
+++ b/master/hu.po
@@ -1,0 +1,283 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Zoltan Hoppár <zoltanh721@fedoraproject.org>, 2014
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2015-04-02 03:06-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Hungarian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"a '%(mount_option)s' csatolási opció hozzáadásra került ehhez: "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "bizonyosodjon meg arról, hogy %d karakter hosszúságú jelszót ad meg"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "root jelszó hosszúsága nem ellenőrzhető (jelszó titkosított)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "'%s' csomag hozzáadásra került a telepítendő csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "'%s' csomag hozzáadásra került az eltávolítandó csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Nincs még kész"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Adatok letöltése"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Nincs profil kiválasztva"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Nincsenek szabályok felállítva az előkészítési fázishoz"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Helytelen tartalom került megadásra. Kérem, adjon meg egy másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Tartalom letöltése sikertelen. Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Tartalom kibontása sikertelen (%s). Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "vagy adjon meg adathalmazt, vagy archiv URL-t alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Tartalom nem található. Kérem adjon meg egy adathalmazt, vagy archív URL-t "
+"alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Tartalom nem található"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Helytelen beállítások észlelve"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Figyelmeztetések jelentek meg"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Minden rendben"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Rossz vagy nem támogatott URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Tartalom letöltése..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr ""
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "Tartalom megváltoztatása"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Biztonsági szabályzat alkalmazása:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Adathalmaz:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Ellenőrző lista:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Válasszon egy profilt alább:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Kiválasztva"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "Vála_sszon egy profilt"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Változtatások amiket meg kell tenni vagy elkészültek:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP Biztonsági könyv előírásainak használata"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "Letöltés"

--- a/master/it.po
+++ b/master/it.po
@@ -1,0 +1,308 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:17-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve essere su una partizione separata o su un volume logico e deve "
+"essere creato nel layout di partizionamento prima che l'installazione possa "
+"avvenire con un profilo di sicurezza"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opzione di montaggio%(mount_option)s'aggiunto per il punto di mount "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assicurati di creare una password con una lunghezza minima di %d personaggi"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossibile controllare la lunghezza della password di root (la password è "
+"criptata)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la password di root è troppo breve, più lunga con almeno %d i caratteri sono"
+" obbligatori"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti da installare"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti esclusi"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Il firewall sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Il firewall sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da aggiungere al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"porto%s'è stato aggiunto all'elenco delle porte da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"fiducia '%s'è stato aggiunto all'elenco dei trust da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da rimuovere dal "
+"firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Si è verificato un errore durante il recupero e il caricamento del contenuto"
+" di sicurezza:%sL'installazione dovrebbe essere interrotta. Vuoi continuare "
+"comunque?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il controllo di integrità del contenuto di sicurezza non è riuscito. "
+"L'installazione dovrebbe essere interrotta. Vuoi continuare comunque?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_POLITICA DI SICUREZZA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Non pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Recupero dei dati di contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Nessun profilo selezionato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Nessuna regola per la fase di pre-installazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenuto non valido fornito. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "URL di contenuto non valido o non supportato, inserisci uno diverso."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Impossibile recuperare il contenuto. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Errore di rete rilevato durante il recupero dei dati. Si prega di verificare"
+" che la rete sia configurata e funzionante."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Il controllo di integrità del contenuto non è riuscito. Non posso usare il "
+"contenuto."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossibile estrarre il contenuto (%s). Inserisci un URL diverso, per "
+"favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profilo con ID '%s'non definito nel contenuto. Seleziona un profilo diverso,"
+" per favore"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Non applicare la politica di sicurezza"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" oppure inserisci il contenuto del flusso di dati o l'URL di archivio di "
+"seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nessun contenuto trovato. Inserisci il contenuto del flusso di dati o l'URL "
+"di archiviazione di seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Errore durante il recupero e il caricamento del contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Nessun contenuto trovato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Rilevata errata configurazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Sono apparsi avvertimenti"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Tutto ok"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "URL non valido o non supportato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Recupero del contenuto ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITICA DI SICUREZZA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambia i contenuti"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Applica la politica di sicurezza:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flusso di dati:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Elenco di controllo:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Scegli il profilo qui sotto:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profilo"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selezionato"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleziona profilo"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifiche che sono state fatte o devono essere fatte:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usare Guida alla sicurezza di SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Ottenere"

--- a/master/ja.po
+++ b/master/ja.po
@@ -1,0 +1,282 @@
+# Ooyama Yosiyuki <qqke6wd9k@apricot.ocn.ne.jp>, 2015. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2020-03-10 01:40-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} "
+"は、別のパーティションもしくは論理ボリューム上になければなりません。また、セキュリティープロファイルがインストールされる前にパーティションレイアウトに作成されなければなりません"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "マウントオプション '%(mount_option)s' が、マウントポイント %(mount_point)s に追加されました"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "%d 文字以上のパスワードを作成してください。"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "root パスワードの長さを確認できません (パスワードは暗号化済み)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root のパスワードが短すぎます。%d 文字以上にする必要があります。"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "パッケージ '%s' が、インストール予定パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "パッケージ '%s' が、除外パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump は起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump は起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "ファイアウォールは起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "ファイアウォールは起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールに追加予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "ポート '%s' が、ファイアウォールに追加予定のポート一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "トラスト '%s' が、ファイアウォールに追加予定のトラスト一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールから削除予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの取得時およびロード時にエラーが発生しました。\n"
+"%s\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの整合性チェックに失敗しました。\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "セキュリティーポリシー(_S)"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "準備ができていません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "コンテンツデータの取得中"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "選択されたプロファイルはありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "プレインストールフェーズのルールがありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "無効なコンテンツが入力されました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "コンテンツ URL が無効またはサポートされていません。別の URL を入力していません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "コンテンツの取得に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "データの取得時にネットワークエラーが発生しました。ネットワークが設定されており、動作していることを確認してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "コンテンツの整合性チェックに失敗しました。コンテンツを使用できません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "コンテンツ (%s) の抽出に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "コンテンツで ID が '%s' のプロファイルが定義されていません。別のプロファイルを選択してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "セキュリティーポリシーを適用しない"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "または、以下にデータストリームコンテンツもしくはアーカイブの URL を入力します。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "コンテンツが見つかりませんでした。以下にデータストリームコンテンツもしくはアーカイブの URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "コンテンツの取得およびロードのエラー"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "コンテンツが見つかりませんでした"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "設定ミスが検出されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "警告が表示されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "すべて OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "無効またはサポートされていない URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "コンテンツの取得中..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "セキュリティーポリシー"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "コンテンツの変更(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "セキュリティーポリシーの適用:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "データストリーム:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "チェックリスト:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "以下のプロファイルを選択:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "プロファイル"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選択済み"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "プロファイルを選択(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "完了済みの変更または必要な変更"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP セキュリティーガイドを使用する(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "取得(_F)"

--- a/master/ko.po
+++ b/master/ko.po
@@ -1,0 +1,280 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2018-09-20 03:07-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Korean\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0}은/는 별도의 파티션이나 논리 볼륨이 있어야 하며 보안 프로파일이 설치되기 전에 파티션 레이아웃을 만들어야 합니다. "
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "마운트 지점 %(mount_point)s의 마운트 옵션 '%(mount_option)s'이/가 추가되었습니다.  "
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "최소 %d자 이상으로 암호를 만들어야 합니다 "
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "root 암호 길이를 확인할 수 없습니다 (암호가 암호화됨)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 암호가 너무 짧습니다. 최소 %d자 이어야 합니다."
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "패키지 '%s'이/가 설치할 패키지 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "패키지 '%s'이/가 제외된 패키지 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "시작시 Kdump가 비활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "시작시 Kdump가 활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "시작시 방화벽이 비활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "시작시 방화벽이 활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에 추가할 서비스 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "포트 '%s'이/가 방화벽에 추가할 포트 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "트러스트 '%s'이/가 방화벽에 추가할 트러스트 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에서 제거할 서비스 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠 가져오기 및 로딩 중 오류가 발생했습니다.:\n"
+"%s\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠에 대한 무결성 검사에 실패했습니다.\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "보안 정책(_S):"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "준비되어 있지 않습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "컨텐츠 데이터를 가져오는 중 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "프로파일이 선택되지 않았습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "사전 설치 단계의 규칙이 없습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "잘못된 내용이 입력되었습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "유효하지 않거나 지원되지 않는 컨텐츠 URL입니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "컨텐츠를 가져오지 못했습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "컨텐츠를 가져오는 중 네트워크 오류가 발생했습니다. 네트워크가 제대로 작동하는지 확인하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "컨텐츠 무결성 검사에 실패했습니다. 컨텐츠를 사용할 수 없습니다. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "컨텐츠 (%s)을/를 가져오지 못했습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID '%s'이/가 프로파일에 정의되어 있지 않습니다. 다른 프로파일을 선택하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "보안 정책을 적용하지 않음 "
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "데이터 스트림 컨텐츠를 입력하거나 다음 URL을 아카이브하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "내용이 없습니다. 데이터 스트림 컨텐츠를 입력하거나 또는 다음 URL을 아카이브하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "컨텐츠 오류 가져오기 및 로딩 오류 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "컨텐츠를 찾을 수 없음 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "설정 오류가 감지되었습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "경고가 표시되었습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "모든 것이 정상입니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "유효하지 않거나 지원되지 않는 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "컨텐츠 가져오는 중..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "보안 정책 "
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "컨텐츠 변경(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "보안 정책 적용:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "데이터 스트림:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "검사 목록:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "프로파일 선택: "
+
+# auto translated by TM merge from project: RHOSP Director Installation and
+# Usage , version: 11-Korean, DocId: master
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "프로파일"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "선택됨 "
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "프로파일 선택(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "완료된 변경사항 또는 필요한 변경사항:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP 보안 가이드 사용(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "가져오기(_F)"

--- a/master/oscap-anaconda-addon.pot
+++ b/master/oscap-anaconda-addon.pot
@@ -1,0 +1,276 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-27 15:53+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:223
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:371
+msgid "Fetching content data"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:638
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No profile selected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:643
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:795
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:803
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:811
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:819
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:828
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:836
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:854
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile, "
+"please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:870
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:901
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:905
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1043
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1050
+msgid "No content found"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1061
+msgid "Misconfiguration detected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1069
+msgid "Everything okay"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1145
+msgid "Invalid or unsupported URL"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1151 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr ""
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr ""
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr ""
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr ""
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr ""
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr ""
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr ""
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr ""

--- a/master/pl.po
+++ b/master/pl.po
@@ -1,0 +1,317 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Bartosz Sapijaszko <bartosz@sapek.net>, 2002
+# dcantrel <dcantrell@redhat.com>, 2011
+# Dimitris Glezos <glezos@indifex.com>, 2011
+# Dimitris Glezos <glezos@transifex.com>, 2011
+# Jacek Smyda <smyda@posexperts.com.pl>, 1998
+# Leszek Matok <lam@lac.pl>, 2004
+# Pawel Szopinski <pawel@szopinski.co.uk>, 2004
+# Piotr Drąg <piotrdrag@gmail.com>, 2014
+# Radosław Zawartko <radzaw@radzaw.one.pl>, 2004
+# sonyam <sonyam@tlen.pl>, 2004
+# Stanisław Małolepszy <smalolepszy@aviary.pl>, 2006
+# Tom Berner <tom@lodz.pl>, 2005
+# Tom Berner <tom@man.lodz.pl>, 2004
+# Wojciech Kapusta <wojciech@aviary.pl>, 2006
+# Piotr Drąg <piotrdrag@gmail.com>, 2015. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2016. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2018. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2020-06-27 05:22-0400\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
+"Language-Team: Polish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pl/)\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musi być na oddzielnej partycji lub woluminie logicznym i musi być "
+"utworzone w układzie partycjonowania, zanim można przeprowadzić instalację "
+"za pomocą profilu bezpieczeństwa"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"dodano opcję montowania „%(mount_option)s” dla punktu montowania "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "proszę się upewnić, że tworzone hasło ma co najmniej %d znaków"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "nie można sprawdzić długości hasła roota (hasło jest zaszyfrowane)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"hasło roota jest za krótkie, wymagane jest dłuższe z co najmniej %d znakami"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "dodano pakiet „%s” do listy pakietów do zainstalowania"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "dodano pakiet „%s” do listy wykluczonych pakietów"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump będzie wyłączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump będzie włączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Zapora sieciowa będzie wyłączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Zapora sieciowa będzie włączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "dodano usługę „%s” do listy usług do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "dodano port „%s” do listy portów do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "dodano zaufanie „%s” do listy zaufań do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "dodano usługę „%s” do listy usług do usunięcia z zapory sieciowej"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Wystąpił błąd podczas pobierania i wczytywania treści bezpieczeństwa:\n"
+"%s\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Sprawdzenie spójności treści bezpieczeństwa się nie powiodło.\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_ZASADY BEZPIECZEŃSTWA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Niegotowe"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Pobieranie danych treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Nie wybrano profilu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Brak reguł dla fazy przedinstalacyjnej"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Podano nieprawidłową treść. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Nieprawidłowy lub nieobsługiwany adres URL treści, proszę wybrać inny."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Pobranie treści się nie powiodło. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Wystąpił błąd sieci podczas pobierania danych. Proszę sprawdzić, czy sieć "
+"została ustawiona i działa poprawnie."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Sprawdzenie integralności treści się nie powiodło. Nie można użyć treści."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Wydobycie treści się nie powiodło (%s). Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"W treści nie określono profilu o identyfikatorze „%s”. Proszę wybrać inny "
+"profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Bez zastosowywania zasad bezpieczeństwa"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" albo podać treść strumienia danych lub podać adres URL archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nie odnaleziono treści. Proszę podać treść strumienia danych lub adres URL "
+"archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Błąd podczas pobierania i wczytywania treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Nie odnaleziono treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Wykryto błędną konfigurację"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Pojawiły się ostrzeżenia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Wszystko jest w porządku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Nieprawidłowy lub nieobsługiwany adres URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Pobieranie treści…"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ZASADY BEZPIECZEŃSTWA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Zmień treść"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Zastosowanie zasad bezpieczeństwa:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Strumień danych:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista do sprawdzenia:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Proszę wybrać profil poniżej:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Wybrane"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wybierz profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Wprowadzone zmiany i zmiany, które muszą zostać wprowadzone:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Użycie przewodnika bezpieczeństwa SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+"Nie odnaleziono treści. Proszę podać treść strumienia danych lub adres URI "
+"archiwum poniżej:"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Pobierz"

--- a/master/pt.po
+++ b/master/pt.po
@@ -1,0 +1,278 @@
+# Manuela Silva <mmsrs@sky.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2015-09-13 10:49-0400\n"
+"Last-Translator: Manuela Silva <mmsrs@sky.com>\n"
+"Language-Team: Portuguese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opção de montagem '%(mount_option)s' adicionada ao ponto de montagem "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"certifique-se que cria a senha com o comprimento mínimo de %d carateres"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"não é possível verificar o comprimento da senha \"root\" (a senha está "
+"encriptada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "POLÍTICA DE _SEGURANÇA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Obter dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Detetada má configuração"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Está tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "URL inválido ou não suportado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "O obter o conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Alterar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicar política de segurança:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Escolha o perfil abaixo:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selecionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecionar perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Alterações que foram concluídas ou precisam de ser concluídas"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utilize o Guia de Segurança SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Obter"

--- a/master/pt_BR.po
+++ b/master/pt_BR.po
@@ -1,0 +1,312 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Marcelo Barbosa <firemanxbr@fedoraproject.org>, 2014
+# Marco Aurélio Krause <ouesten@me.com>, 2015. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:12-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pt_BR/)\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve estar em uma partição separada ou em um volume lógico e deve ser "
+"criado no layout de particionamento antes que a instalação possa ocorrer com"
+" um perfil de segurança"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opção de montagem '%(mount_option)s' adicionado para o ponto de montagem "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"certifique-se de criar uma senha com comprimento mínimo de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Não é possível verificar o comprimento da senha do root (senha "
+"criptografada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"A senha root é muito curta, uma mais longa com pelo menos %d caracteres são "
+"obrigatórios"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacote '%s' foi adicionado à lista de pacotes a serem instalados"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacote '%s' foi adicionado a lista de pacotes a serem excluídos"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "O Kdump será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "O Kdump será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem adicionados ao "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"port '%s'foi adicionado à lista de portas a serem adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"Confiar em '%s'foi adicionado à lista de relações de confiança a serem "
+"adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem removidos do firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ocorreu um erro ao buscar e carregar o conteúdo de segurança:\n"
+"%s\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"A verificação de integridade do conteúdo de segurança falhou.\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_POLÍTICA DE SEGURANÇA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Ainda não esta pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Buscando dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Não há regras para a fase de pré-instalação"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Conteúdo fornecido é inválido. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL do conteúdo inválido ou não suportado, entre com um outro diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Falha ao buscar conteúdo. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Foi encontrado um erro na rede ao buscar dados. Verifique se a rede está "
+"configurada e funcionando."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"A verificação de integridade do conteúdo falhou. Não é possível usar o "
+"conteúdo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Falha ao extrair o conteúdo (%s). Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Perfil com ID '%s' não definido no conteúdo. Selecione um perfil diferente, "
+"por favor"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Não aplicar a política de segurança"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "ou inserir conteúdo de fluxo de dados ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenhum conteúdo encontrado. Por favor entre com conteúdo de fluxo de dados "
+"ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Erro ao buscar e carregar o conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Misconfiguration detectado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Advertências surgidas"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "URL inválida ou não suportada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Buscando conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Mudar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicar política de segurança:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Fluxo de dados:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Escolha o perfil abaixo:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selecionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecione o perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "As alterações que foram feitas ou precisam ser feitas:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Use SCAP Segurança Guia"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "Buscar(_F)"

--- a/master/ru.po
+++ b/master/ru.po
@@ -1,0 +1,300 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-02-12 02:17-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} должен быть на отдельном разделе или логическом томе и должен быть "
+"создан в макете разбиения до того, как установка может произойти с профилем "
+"безопасности"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"mount option '%(mount_option)s'добавлен для точки монтирования "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "не забудьте создать пароль с минимальной длиной %d персонажи"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "не удается проверить длину пароля root (пароль зашифрован)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"пароль root слишком короткий, более длинный с по крайней мере %d требуется "
+"персонаж"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s'добавлен в список установленных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s'добавлен в список исключенных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Брандмауэр будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Брандмауэр будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"порт '%s'добавлен в список портов, которые будут добавлены в брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"доверие \"%s'добавлен в список доверенностей, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые необходимо удалить из "
+"брандмауэра"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ошибка получения и загрузки содержимого безопасности:%sУстановка должна быть"
+" прервана. Вы все равно хотите продолжить?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Не удалось проверить целостность содержимого безопасности. Установка должна "
+"быть прервана. Вы все равно хотите продолжить?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_ПОЛИТИКА БЕЗОПАСНОСТИ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Не готов"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Получение данных контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Не выбран профиль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Нет правил для этапа предварительной установки"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Недопустимый контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Неверный или неподдерживаемый URL-адрес контента, введите другой."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не удалось получить контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Ошибка сети при сборе данных. Убедитесь, что сеть настроена и работает."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Не удалось проверить целостность содержимого. Невозможно использовать "
+"контент."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Не удалось извлечь контент (%s). Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профиль с идентификатором '%s'не определено в контенте. Выберите другой "
+"профиль, пожалуйста"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Не применять политику безопасности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr " или введите содержимое потока данных или URL-адрес архива ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Контент не найден. Введите содержимое потока данных или URL-адрес архива "
+"ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Ошибка получения и загрузки содержимого"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Не найдено ни одного контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Обнаружено несоответствие"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Появились предупреждения"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Все в порядке"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Недействительный или неподдерживаемый URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Получение контента ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПОЛИТИКА БЕЗОПАСНОСТИ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Изменить контент"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Применение политики безопасности:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Поток данных:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Контрольный список:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Выберите профиль ниже:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профиль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "выбранный"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Выбрать профиль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Изменения, которые были сделаны или должны быть выполнены:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Используйте руководство по безопасности SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Получить"

--- a/master/sr.po
+++ b/master/sr.po
@@ -1,0 +1,283 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Momcilo Medic <medicmomcilo@gmail.com>, 2014
+# Momcilo Medic <medicmomcilo@gmail.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2015-04-18 01:39-0400\n"
+"Last-Translator: Momcilo Medic <medicmomcilo@gmail.com>\n"
+"Language-Team: Serbian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/sr/)\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"прикључна опција '%(mount_option)s' додата за прикључну тачку "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "изаберите шифру од најмање %d карактера"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "немогуће проверити дужину root шифре (шифра је криптована)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s' је додат на листу пакета за инсталацију"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s' је додат на листу искључених пакета"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "_БЕЗБЕДНОСНИ МОДЕЛ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Није спремно"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Преузимање података о садржају"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Није изабран профил"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Нема правила за пред-инсталациону фазу"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Неисправан садржај пружен. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Неуспешно преузимање садржаја. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Неуспешно извлачење садржаја (%s). Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Не примењујем полису безбедности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "или унесите садржајни или архивски URL за stream података испод:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Садржај није пронађен. Молим унесите садржајни или архивски URL за stream "
+"података:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Садржај није пронађен"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Погрешно подешавање откривено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Упозорења су се појавила"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Све је у реду"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Неисправан или неподржан URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Преузимање садржаја..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "БЕЗБЕДНОСНИ МОДЕЛ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Промена садржаја"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Примени сигурносну политику:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Stream података:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Листа:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Изаберите профил:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профил"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Изабрано"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Изаберите профил"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Промене које су урађене или требају да се ураде:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Користи SCAP сигурносни водич"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Преузми"

--- a/master/uk.po
+++ b/master/uk.po
@@ -1,0 +1,297 @@
+# Yuri Chornoivan <yurchor@ukr.net>, 2015.
+# Yuri Chornoivan <yurchor@ukr.net>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2018-07-02 03:40-0400\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} має бути окремим розділом або логічним томом, його має бути створено у "
+"компонуванні розділів до того, як стане можливим встановлення із профілем "
+"захисту"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"для точки монтування %(mount_point)s додано параметр монтування "
+"«%(mount_option)s»"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "довжина пароля має бути не меншою за %d символів"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "не вдалося перевірити довжину пароля root (пароль зашифровано)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"пароль root є надто коротким, потрібен довший, принаймні із %d символів"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "до списку встановлюваних пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "до списку виключених пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump буде вимкнено при запуску"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump буде увімкнено при запуску"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "Брандмауер буде вимкнено при запуску"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "Брандмауер буде увімкнено при запуску"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"службу «%s» було додано до списку служб, які слід додати до брандмауера"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"порт «%s» було додано до списку портів, які слід додати до брандмауера"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"запис довіри «%s» було додано до списку записів довіри, які слід додати до "
+"брандмауера"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"службу «%s» було додано до списку служб, які слід вилучити з брандмауера"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Під час отримання та завантаження даних захисту сталася помилка:\n"
+"%s\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Дані захисту не пройшли перевірку на цілісність.\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "П_РАВИЛА ЗАХИСТУ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "Неготовий"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "Отримуємо дані"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "Не вибрано жодного профілю"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "Правил для кроку перед встановленням немає"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Надано некоректні дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Некоректна або непідтримувана адреса даних. Будь ласка, введіть якусь іншу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не вдалося отримати дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Під час спроби отримання даних сталася помилка, пов’язана із мережею. Будь "
+"ласка, перевірте, чи правильно налаштовано з’єднання, та чи є воно "
+"працездатним."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Дані не пройшли перевірку на цілісність. Їхнє використання неможливе."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Не вдалося видобути дані (%s). Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профіль з ідентифікатором «%s» у даних не визначено. Виберіть, будь ласка, "
+"інший профіль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "Не застосовуємо правил захисту"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr " або вкажіть адресу потоку даних чи архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Даних не знайдено. Будь ласка, вкажіть адресу потоку даних або архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "Помилка під час спроби отримання та завантаження даних"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "Даних не знайдено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "Виявлено помилки у налаштуваннях"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "Отримано попередження"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "Все гаразд"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "Некоректна або непідтримувана адреса"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Отримуємо дані…"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПРАВИЛА ЗАХИСТУ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "З_міна даних"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Застосувати правило захисту:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Потік даних:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Список для перевірки:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Виберіть профіль:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профіль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Позначене"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Вибрати профіль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Зміни, які внесено або має бути внесено:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "Ви_користати настанови із захисту SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Отримати"

--- a/master/zh_CN.po
+++ b/master/zh_CN.po
@@ -1,0 +1,278 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2018-11-21 11:52-0500\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Chinese (Simplified)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必须在一个独立的分区或逻辑卷上，并需要在带有安全档案的安装进行前，在分区布局中创建"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "为挂载点 %(mount_point)s 添加的挂载选项 '%(mount_option)s'"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "确保创建的密码长度最少为 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "无法检查 root 密码的长度（密码已加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 密码太短，它需要最少包括 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "软件包 '%s' 已被添加到要被安装的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "软件包 '%s' 已被添加到排除的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump 将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump 将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "防火墙将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "防火墙将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要加到防火墙的服务列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "端口 '%s' 已被添加到要加到防火墙的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任 '%s' 已被添加到要加到防火墙的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要从防火墙删除的服务列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"在获取和加载安全内容时出错：\n"
+"%s\n"
+"安装应该被终止。您希望继续吗？"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"对安全内容的完整性检查失败。\n"
+"安装应该被终止。您希望继续吗？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "安全策略（_S）："
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "未就绪"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "获取内容数据"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "没有选择 profile"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "没有预安装阶段的规则"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供无效的内容。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "无效或不支持的内容 URL，请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "获取内容失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "在获取数据时出现网络错误。请检查网络是否正常。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "内容的完整性检查失败。不能使用这个内容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "提取内容 (%s) 失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID 为 '%s' 的档案没有在内容中定义。请选择一个不同的档案"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "没有应用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr "或输入数据流内容或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "没有找到内容。请输入数据流或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "获取并加载内容错误"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "没有找到内容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "发现错误配置"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "出现的警告"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "一切正常"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "无效或不支持的 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "获取内容..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全策略"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "修改内容(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "应用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "数据流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "检查列表："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "选择档案："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "档案"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "选择"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "选择档案(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的改变"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "使用 SCAP 安全指南(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "获取(_F)"

--- a/master/zh_TW.po
+++ b/master/zh_TW.po
@@ -1,0 +1,274 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-06-01 14:12+0200\n"
+"PO-Revision-Date: 2019-01-15 11:26-0500\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:400
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必須位於單獨的分區或邏輯卷上，並且必須在分區佈局中創建，然後才能使用安全配置文件進行安裝"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:411
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "掛載選項'%(mount_option)s'為掛載點添加了 %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:520
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "確保以最小的長度創建密碼 %d 人物"
+
+#: ../org_fedora_oscap/rule_handling.py:527
+msgid "cannot check root password length (password is crypted)"
+msgstr "無法檢查root密碼長度（密碼被加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:533
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root密碼太短，至少有一個 %d 字符是必需的"
+
+#: ../org_fedora_oscap/rule_handling.py:637
+#: ../org_fedora_oscap/rule_handling.py:652
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "包'%s'已添加到要安裝的軟件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:661
+#: ../org_fedora_oscap/rule_handling.py:676
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "包'%s'已添加到已排除的包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:777
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump將在啟動時被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:779
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+msgid "Firewall will be disabled on startup"
+msgstr "防火牆將在啟動時禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:939
+msgid "Firewall will be enabled on startup"
+msgstr "防火牆將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:947
+#: ../org_fedora_oscap/rule_handling.py:986
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服務'%s'已添加到要添加到防火牆的服務列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:954
+#: ../org_fedora_oscap/rule_handling.py:999
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "港口 '%s'已被添加到要添加到防火牆的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:961
+#: ../org_fedora_oscap/rule_handling.py:1012
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任'%s'已被添加到要添加到防火牆的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:1024
+#: ../org_fedora_oscap/rule_handling.py:1039
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服務'%s'已被添加到要從防火牆中刪除的服務列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "獲取和加載安全內容時出錯：%s安裝應該中止。你想繼續嗎？"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "安全內容的完整性檢查失敗。安裝應該中止。你想繼續嗎？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_SECURITY POLICY"
+msgstr "安全政策（_S）"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:221
+msgid "Not ready"
+msgstr "沒有準備好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:369
+msgid "Fetching content data"
+msgstr "獲取內容數據"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:636
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1051
+msgid "No profile selected"
+msgstr "沒有選擇個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+msgid "No rules for the pre-installation phase"
+msgstr "沒有預安裝階段的規則"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:793
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供的內容無效。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:801
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "無效或不受支持的內容網址，請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:809
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "無法獲取內容。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:817
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "獲取數據時遇到網絡錯誤。請檢查網絡是否已設置並正常運行。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:826
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "內容的完整性檢查失敗。無法使用內容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:834
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "無法提取內容（%s）。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:852
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "帶ID的個人資料'%s'沒有在內容中定義。請選擇其他個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:868
+msgid "Not applying security policy"
+msgstr "不應用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:899
+msgid " or enter data stream content or archive URL below:"
+msgstr " 或輸入以下數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:903
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "找不到任何內容。請在下面輸入數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1041
+msgid "Error fetching and loading content"
+msgstr "獲取和加載內容時出錯"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1048
+msgid "No content found"
+msgstr "找不到任何內容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1059
+msgid "Misconfiguration detected"
+msgstr "檢測到配置錯誤"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1065
+msgid "Warnings appeared"
+msgstr "警告出現了"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1067
+msgid "Everything okay"
+msgstr "一切都好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1143
+msgid "Invalid or unsupported URL"
+msgstr "網址無效或不受支持"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1149 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "獲取內容......"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全政策"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "改變內容（_C）"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "應用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "數據流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "清單："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "選擇以下資料："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "輪廓"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "選擇個人資料（_S）"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的更改："
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_使用SCAP安全指南（_U）"
+
+#: tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URI below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "取（_F）"

--- a/rhel7-branch/ca.po
+++ b/rhel7-branch/ca.po
@@ -1,0 +1,301 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
+# Ding-Yi Chen <dingyichen@gmail.com>, 2015. #zanata
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2015-09-29 07:31-0400\n"
+"Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
+"Language-Team: Catalan (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/ca/)\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"l'opció de muntatge '%(mount_option)s' va afegir-se al punt de muntatge "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assegureu-vos de crear una contrasenya amb una mida mínima de %d caràcters"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no es pot comprovar la mida de la contrasenya de root (la contrasenya està "
+"xifrada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets instal·lats"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets exclosos"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Hi va haver un error en la captura i la càrrega del contingut de seguretat:\n"
+"%s\n"
+"S'hauria d'avortar la instal·lació. Voleu continuar de totes maneres?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ha fallat la comprovació de la integritat del contingut de seguretat.\n"
+"S'hauria d'avortar la instal·lació. Voleu continuar de totes maneres?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "PERFIL DE _SEGURETAT"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "No està llest"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "S'estan obtenint les dades del contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "No s'ha seleccionat cap perfil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Sense regles per a la fase de pre-instal·lació"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"S'ha proporcionat un context no vàlid. Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"L'URL del contingut no és vàlid o no està admès, si us plau, introduïu-ne un"
+" altre diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"L'obtenció del contingut ha fallat. Si us plau, introduïu un URL diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"S'ha detectat un error de xarxa quan es capturaven les dades. Reviseu que la"
+" xarxa estigui configurada i que aquesta estigui funcionant."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Ha fallat la comprovació de la integritat del contingut. No es pot utilitzar"
+" el contingut."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"L'extracció del contingut ha fallat (%s). Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"El perfil amb l'id. «%s» no està definit en el contingut. Seleccioneu un "
+"perfil diferent, si us plau"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Sense aplicar la política de seguretat"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"A continuació introduïu el contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No s'ha trobat cap contingut. Si us plau, a continuació introduïu el "
+"contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "S'ha produït un error en capturar i carregar el contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "No s'ha trobat cap contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "S'ha detectat una configuració errònia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Advertències que van aparèixer"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Tot està bé"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "L'URL no és vàlid o no està admès"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "S'està obtenint el contingut..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURETAT"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Canvia el contingut"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplica la política de seguretat:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de dades:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Llista de comprovació:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Trieu el perfil a sota:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionat"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecciona el perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Els canvis que es van fer o s'han de fer:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utilitza la guia de seguretat SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Obté"

--- a/rhel7-branch/cs.po
+++ b/rhel7-branch/cs.po
@@ -1,0 +1,289 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# vpodzime <vpodzime@redhat.com>, 2014-2015
+# Zdenek <chmelarz@gmail.com>, 2016. #zanata
+# Zdenek <chmelarz@gmail.com>, 2017. #zanata
+# Daniel Rusek <mail@asciiwolf.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2018-10-23 11:02-0400\n"
+"Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
+"Language-Team: Czech (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/cs/)\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musí být na samostatném diskovém nebo logickém oddílu a musí být "
+"vytvořen v rozdělení oddílů předtím, než bude moci být zahájena instalace s "
+"bezpečnostním profilem"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "parametr '%(mount_option)s' přidán pro přípojný bod %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "ujistěte se, že heslo bude mít minimální délku %d znaků"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "nelze zkontrolovat délku hesla uživatele root (heslo je šifrováno)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"heslo uživatele root je příliš krátké, je vyžadováno delší heslo s nejméně "
+"%d znaky"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "balík '%s' byl přidán do seznamu instalovaných balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "balík '%s' byl přidán do seznamu vyloučených balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port '%s' byl přidán na seznam portů k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "důvěra '%s' byla přidána na seznam důvěr k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k odebrání z firewallu"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Při získávání a načítání bezpečnostních dat došlo k chybě:\n"
+"%s\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Test integrity bezpečnostních dat neprošel.\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_POLITIKA ZABEZPEČENÍ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Není připraven"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Načítají se data"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Není vybrán žádný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Žádná pravidla pro předinstalační fázi"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Nevalidní data. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Nevalidní nebo nepodporované datové URL, zadejte prosím jiné."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Načítání dat selhalo. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Během získávání dat se vyskytla chyba sítě. Zkontrolujte prosím, že je síť "
+"nastavena a funkční."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Test integrity dat neprošel. Nelze použít tato data."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Rozbalování dat selhalo (%s). Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "Profil s ID '%s' není definován v datech. Vyberte prosím jiný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Neaplikovat bezpečnostní politiku"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "nebo zadejte URL data streamu, případně archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenalezen žádný zdroj dat. Prosím uveďte URL k data streamu nebo archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Chyba při získávání a načítání dat"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Žádná data k dispozici"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Detekována nesprávná konfigurace"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Varování"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Vše v pořádku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Nevalidní nebo nepodporované URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Načítám data..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIKA ZABEZPEČENÍ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Jiná data"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplikovat bezpečnostní politiku:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Data stream:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Vyberte profil:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Vybrán"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Vybrat profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Změny, které byly nebo musejí být provedeny:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Použít SCAP Security Guide"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Načíst"

--- a/rhel7-branch/de.po
+++ b/rhel7-branch/de.po
@@ -1,0 +1,307 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:07-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} muss sich auf einer separaten Partition oder einem logischen Volume "
+"befinden und muss im Partitionslayout erstellt werden, bevor die "
+"Installation mit einem Sicherheitsprofil erfolgen kann"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"Einhängeoption '%(mount_option)s'hinzugefügt für den Einhängepunkt "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Stellen Sie sicher, dass Sie ein Kennwort mit einer Mindestlänge von "
+"erstellen %d Zeichen"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Länge des Root-Passworts kann nicht geprüft werden (Passwort wird "
+"verschlüsselt)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"Das root-Passwort ist zu kurz, ein längeres mit mindestens %d Zeichen sind "
+"erforderlich"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "Paket \"%s'wurde der Liste der zu installierenden Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "Paket \"%s'wurde der Liste der ausgeschlossenen Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Die Firewall wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Die Firewall wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die zur Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"Hafen '%s'wurde der Liste der Ports hinzugefügt, die der Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"vertrauen '%s'wurde der Liste der Vertrauensstellungen hinzugefügt, die der "
+"Firewall hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die aus der Firewall "
+"entfernt werden sollen"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Beim Abrufen und Laden des Sicherheitsinhalts ist ein Fehler "
+"aufgetreten:%sDie Installation sollte abgebrochen werden. Möchten Sie "
+"trotzdem fortfahren?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Die Integritätsprüfung des Sicherheitsinhalts ist fehlgeschlagen. Die "
+"Installation sollte abgebrochen werden. Möchten Sie trotzdem fortfahren?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_SECURITY POLICY"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Nicht bereit"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Inhaltsdaten abrufen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Kein Profil ausgewählt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Keine Regeln für die Vorinstallationsphase"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Ungültiger Inhalt bereitgestellt Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Ungültige oder nicht unterstützte Inhalts-URL. Bitte geben Sie eine andere "
+"URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht abgerufen werden. Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Beim Abrufen von Daten ist ein Netzwerkfehler aufgetreten. Bitte überprüfen "
+"Sie, ob das Netzwerk eingerichtet ist und funktioniert."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Die Integritätsprüfung des Inhalts ist fehlgeschlagen. Der Inhalt kann nicht"
+" verwendet werden."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht extrahiert werden (%s). Bitte geben Sie eine andere URL "
+"ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profil mit ID '%s'im Inhalt nicht definiert. Bitte wählen Sie ein anderes "
+"Profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Keine Sicherheitsrichtlinie anwenden"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr " oder geben Sie den Datenstrominhalt oder die Archiv-URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Kein Inhalt gefunden Bitte geben Sie den Datenstrom-Inhalt oder die Archiv-"
+"URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Fehler beim Abrufen und Laden von Inhalten"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Kein Inhalt gefunden"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Fehlkonfiguration erkannt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Warnungen erschienen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Alles okay"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Ungültige oder nicht unterstützte URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Inhalt wird abgerufen ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "SICHERHEITSPOLITIK"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Ändern Sie den Inhalt"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Sicherheitsrichtlinie anwenden:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Datenstrom:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checkliste:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Wählen Sie unten ein Profil:"
+
+#: tmp/oscap.glade.h:7
+#, fuzzy
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+#, fuzzy
+msgid "Selected"
+msgstr "Ausgewählt"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wähle Profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Änderungen, die vorgenommen wurden oder durchgeführt werden müssen:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Verwenden Sie das SCAP-Sicherheitshandbuch"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Fetch"

--- a/rhel7-branch/es.po
+++ b/rhel7-branch/es.po
@@ -1,0 +1,312 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Gerardo Rosales <grosale86@gmail.com>, 2014
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2016. #zanata
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2017. #zanata
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:27-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} debe estar en una partición separada o en un volumen lógico y debe "
+"crearse en el diseño de particiones antes de que se inicie la instalación "
+"con un perfil de seguridad"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opciones de montaje '%(mount_option)s' añadidas para el punto de montaje "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Asegúrese de crear una contraseña con una longitud mínima de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no se puede comprobar la longitud de la contraseña raíz(la contraseña está "
+"encriptada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la contraseña de root es demasiado corta, se exige una más larga con al "
+"menos %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes a instalar"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes excluidos"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Se desactivará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Se activará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Se desactivará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Se activará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a añadir al "
+"cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"el puerto '%s' se ha añadido a la lista de puertos a añadir al cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"confiar%s'se ha agregado a la lista de fideicomisos que se agregarán al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a quitar del "
+"cortafuegos"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Se produjo un error al obtener y cargar el contenido de seguridad:\n"
+"%s\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Falló la comprobación de integridad del contenido de seguridad.\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_POLÍTICA DE SEGURIDAD"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "No está listo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Obteniendo datos de contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Ningún perfil seleccionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Ninguna regla para la fase de pre-instalación"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Contenido proporcionado inválido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"La URL del contenido no es válida o no está admitida, por favor introduzca "
+"una nueva."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Falló la obtención de contenido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Se produjo un error de red al obtener los datos. Compruebe que la red está "
+"configurada y en funcionamiento."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Falló la comprobación de la integridad del contenido. No se puede usar el "
+"mismo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Fallo al extraer el contenido(%s). Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"El perfil con ID '%s' no está definido en el contenido. Elija uno diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "No se aplica política de seguridad"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"o ingrese el contenido de flujo de datos o archivo URL a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No se encontró contenido. Por favor ingrese un contenido de flujo de datos o"
+" un archivo a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Error al obtener y cargar el contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "No se encontró contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Configuración errónea detectada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Advertencias aparecieron"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Todo está bien"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "URL no soportada o es inválida"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Obteniendo contenido..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURIDAD"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambiando contenido"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicando política de seguridad:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flujo de datos:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista de comprobación:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Elija un perfil a continuación:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleccionar perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Cambios que fueron o serán hechos:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usar Guía de seguridad SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Obtener"

--- a/rhel7-branch/fr.po
+++ b/rhel7-branch/fr.po
@@ -1,0 +1,308 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# dominique bribanick <chepioq@gmail.com>, 2014
+# Jérôme Fenal <jfenal@gmail.com>, 2014
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:26-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/fr/)\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} doit être sur une partition ou un volume logique séparé et doit être "
+"créé dans la structure de partitionnement avant que l'installation puisse "
+"avoir lieu avec un profil de sécurité."
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"option de montage « %(mount_option)s » ajoutée au point de montage "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assurez-vous de créer un mot de passe d'une longueur minimale de %d "
+"caractères"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossible de vérifier la longueur du mot de passe de root (mot de passe "
+"chiffré)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"le mot de passe de root est trop court, une longueur d'au moins %d "
+"caractères est requise"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à installer"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à exclure"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Le pare-feu va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Le pare-feu va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"trust « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à retirer du pare-feu"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il y a eu une erreur lors de l'extraction et du chargement du contenu de sécurité :\n"
+"%s\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Le contrôle d'intégrité du contenu de sécurité a échoué.\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_POLITIQUE DE SÉCURITÉ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Pas prêt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Récupération des données de contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Aucun profil sélectionné"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Aucune règle pour la phase de pré-installation"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenu fourni invalide. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL de contenu non prise en charge ou non valide, veuillez saisir une URL "
+"différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Échec de la récupération du contenu. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Erreur de réseau lors de l'extraction des données. Veuillez vérifier que le "
+"réseau ait été installé et fonctionne correctement."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Le contrôle d'intégrité du contenu a échoué. Impossible d'utiliser le "
+"contenu."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossible d'extraire le contenu (%s). Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Le profil ayant pour ID « %s »n'est pas défini dans le contenu. Sélectionner"
+" un autre profil, s'il vous plaît."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "N'applique pas la politique de sécurité"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"ou saisir un flux de données de contenu ou l'URL d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Contenu introuvable. Merci de saisir un flux de données de contenu ou l'URL "
+"d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Erreur d'extraction et de chargement du contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Contenu introuvable"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Mauvaise configuration détectée"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Des avertissements sont apparus"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Tout est OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "URL invalide ou non prise en charge"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Récupération du contenu..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIQUE DE SÉCURITÉ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Modifier le contenu"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Application des politiques de sécurité :"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de données :"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Liste de vérifications :"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Choisir le profil ci-dessous :"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Sélectionné"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Sélectionner le profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifications réalisées ou à faire :"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utiliser le guide de sécurité SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Récupérer"

--- a/rhel7-branch/hu.po
+++ b/rhel7-branch/hu.po
@@ -1,0 +1,302 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Zoltan Hoppár <zoltanh721@fedoraproject.org>, 2014
+# Teknős Ferenc <teknos.ferenc@gmail.com>, 2018. #zanata
+# Teknős Ferenc <teknos.ferenc@gmail.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-03-17 07:29-0400\n"
+"Last-Translator: Teknős Ferenc <teknos.ferenc@gmail.com>\n"
+"Language-Team: Hungarian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"A {0} -nek külön partíción vagy logikai köteten kell lennie, és létre kell "
+"hoznia a particionálási elrendezésben, mielőtt a telepítés megtörténhet "
+"biztonsági profilon"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"a '%(mount_option)s' csatolási opció hozzáadásra került ehhez: "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "bizonyosodjon meg arról, hogy %d karakter hosszúságú jelszót ad meg"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "root jelszó hosszúsága nem ellenőrzhető (jelszó titkosított)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"root jelszó túl rövid, de hosszabbnak kell lennie legalább %d karakterrel"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "'%s' csomag hozzáadásra került a telepítendő csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "'%s' csomag hozzáadásra került az eltávolítandó csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "A Kdump indításkor le lesz tiltva"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "A Kdump indításkor engedélyezve lesz"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "A tűzfal indításkor le lesz tiltva"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "A tűzfal engedélyezve lesz az indításkor"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"szolgáltatás \"%s\" lett hozzáadva a tűzfalhoz hozzáadandó szolgáltatások "
+"listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port \"%s\" lett hozzáadva a tűzfalhoz hozzáadandó portok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"a \"%s\" szolgáltatás hozzá lett adva a tűzfalhoz hozzáadandó megbízhatók "
+"listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"szolgáltatás \"%s\" lett hozzáadva a tűzfalról eltávolítandó szolgáltatások "
+"listájához"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Hiba történt a biztonsági tartalom lekérése és betöltése során:\n"
+"%s\n"
+"A telepítést meg kell szakítani. Szeretné folytatni?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"A biztonsági tartalom integritásának ellenőrzése sikertelen.\n"
+"A telepítést meg kell szakítani. Szeretné folytatni?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_BIZTONSÁGI HÁZIREND"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Nincs még kész"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Adatok letöltése"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Nincs profil kiválasztva"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Nincsenek szabályok felállítva az előkészítési fázishoz"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Helytelen tartalom került megadásra. Kérem, adjon meg egy másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Érvénytelen vagy nem támogatott tartalom URL, kérjük, írjon be másikat."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Tartalom letöltése sikertelen. Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Hálózati hiba történt az adatok lekérésekor. Ellenőrizze, hogy a hálózat "
+"beállítása és működése megfelelő."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Nem sikerült a tartalom integritásának ellenőrzése. A tartalom nem "
+"használható."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Tartalom kibontása sikertelen (%s). Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"A (z) \"%s\" azonosítójú profil nem szerepel a tartalomban. Kérem válasszon "
+"másik profilt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Nem alkalmazható a biztonsági házirend"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "vagy adjon meg adathalmazt, vagy archiv URL-t alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Tartalom nem található. Kérem adjon meg egy adathalmazt, vagy archív URL-t "
+"alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Hiba történt a tartalom lekérése és betöltése során"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Tartalom nem található"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Helytelen beállítások észlelve"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Figyelmeztetések jelentek meg"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Minden rendben"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Rossz vagy nem támogatott URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Tartalom letöltése..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "BIZTONSÁGI HÁZIREND"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "Tartalom megváltoztatása"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Biztonsági házirend alkalmazása:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Adathalmaz:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Ellenőrző lista:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Válasszon egy profilt alább:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Kiválasztva"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "Vála_sszon egy profilt"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Változtatások amiket meg kell tenni vagy elkészültek:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP Biztonsági könyv előírásainak használata"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "Letöltés"

--- a/rhel7-branch/it.po
+++ b/rhel7-branch/it.po
@@ -1,0 +1,302 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:28-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve essere su una partizione separata o su un volume logico e deve "
+"essere creato nel layout di partizionamento prima che l'installazione possa "
+"avvenire con un profilo di sicurezza"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opzione di montaggio%(mount_option)s'aggiunto per il punto di mount "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assicurati di creare una password con una lunghezza minima di %d personaggi"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossibile controllare la lunghezza della password di root (la password è "
+"criptata)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la password di root è troppo breve, più lunga con almeno %d i caratteri sono"
+" obbligatori"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti da installare"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti esclusi"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Il firewall sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Il firewall sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da aggiungere al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"porto%s'è stato aggiunto all'elenco delle porte da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"fiducia '%s'è stato aggiunto all'elenco dei trust da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da rimuovere dal "
+"firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Si è verificato un errore durante il recupero e il caricamento del contenuto"
+" di sicurezza:%sL'installazione dovrebbe essere interrotta. Vuoi continuare "
+"comunque?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il controllo di integrità del contenuto di sicurezza non è riuscito. "
+"L'installazione dovrebbe essere interrotta. Vuoi continuare comunque?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_POLITICA DI SICUREZZA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Non pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Recupero dei dati di contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Nessun profilo selezionato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Nessuna regola per la fase di pre-installazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenuto non valido fornito. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "URL di contenuto non valido o non supportato, inserisci uno diverso."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Impossibile recuperare il contenuto. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Errore di rete rilevato durante il recupero dei dati. Si prega di verificare"
+" che la rete sia configurata e funzionante."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Il controllo di integrità del contenuto non è riuscito. Non posso usare il "
+"contenuto."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossibile estrarre il contenuto (%s). Inserisci un URL diverso, per "
+"favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profilo con ID '%s'non definito nel contenuto. Seleziona un profilo diverso,"
+" per favore"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Non applicare la politica di sicurezza"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" oppure inserisci il contenuto del flusso di dati o l'URL di archivio di "
+"seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nessun contenuto trovato. Inserisci il contenuto del flusso di dati o l'URL "
+"di archiviazione di seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Errore durante il recupero e il caricamento del contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Nessun contenuto trovato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Rilevata errata configurazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Sono apparsi avvertimenti"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Tutto ok"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "URL non valido o non supportato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Recupero del contenuto ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITICA DI SICUREZZA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambia i contenuti"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Applica la politica di sicurezza:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flusso di dati:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Elenco di controllo:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Scegli il profilo qui sotto:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profilo"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selezionato"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleziona profilo"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifiche che sono state fatte o devono essere fatte:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usare Guida alla sicurezza di SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Ottenere"

--- a/rhel7-branch/ja.po
+++ b/rhel7-branch/ja.po
@@ -1,0 +1,277 @@
+# Ludek Janda <ljanda@redhat.com>, 2017. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2020-03-10 01:42-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} "
+"は、別のパーティションもしくは論理ボリューム上になければなりません。また、セキュリティープロファイルがインストールされる前にパーティションレイアウトに作成されなければなりません"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "マウントオプション '%(mount_option)s' が、マウントポイント %(mount_point)s に追加されました"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "%d 文字以上のパスワードを作成してください。"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "root パスワードの長さを確認できません (パスワードは暗号化済み)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root のパスワードが短すぎます。%d 文字以上にする必要があります。"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "パッケージ '%s' が、インストール予定パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "パッケージ '%s' が、除外パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump は起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump は起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "ファイアウォールは起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "ファイアウォールは起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールに追加予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "ポート '%s' が、ファイアウォールに追加予定のポート一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "トラスト '%s' が、ファイアウォールに追加予定のトラスト一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールから削除予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの取得時およびロード時にエラーが発生しました。\n"
+"%s\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの整合性チェックに失敗しました。\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "セキュリティーポリシー(_S)"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "準備ができていません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "コンテンツデータの取得中"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "選択されたプロファイルはありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "プレインストールフェーズのルールがありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "無効なコンテンツが入力されました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "コンテンツ URL が無効またはサポートされていません。別の URL を入力していません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "コンテンツの取得に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "データの取得時にネットワークエラーが発生しました。ネットワークが設定されており、動作していることを確認してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "コンテンツの整合性チェックに失敗しました。コンテンツを使用できません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "コンテンツ (%s) の抽出に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "コンテンツで ID が '%s' のプロファイルが定義されていません。別のプロファイルを選択してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "セキュリティーポリシーを適用しない"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "または、以下にデータストリームコンテンツもしくはアーカイブの URL を入力します。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "コンテンツが見つかりませんでした。以下にデータストリームコンテンツもしくはアーカイブの URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "コンテンツの取得およびロードのエラー"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "コンテンツが見つかりませんでした"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "設定ミスが検出されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "警告が表示されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "すべて OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "無効またはサポートされていない URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "コンテンツの取得中..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "セキュリティーポリシー"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "コンテンツの変更(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "セキュリティーポリシーの適用:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "データストリーム:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "チェックリスト:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "以下のプロファイルを選択:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "プロファイル"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選択済み"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "プロファイルを選択(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "完了済みの変更または必要な変更"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP セキュリティーガイドを使用する(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "取得(_F)"

--- a/rhel7-branch/ko.po
+++ b/rhel7-branch/ko.po
@@ -1,0 +1,275 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2018-09-20 02:59-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Korean\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0}은/는 별도의 파티션이나 논리 볼륨이 있어야 하며 보안 프로파일이 설치되기 전에 파티션 레이아웃을 만들어야 합니다. "
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "마운트 지점 %(mount_point)s의 마운트 옵션 '%(mount_option)s'이/가 추가되었습니다.  "
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "최소 %d자 이상으로 암호를 만들어야 합니다 "
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "root 암호 길이를 확인할 수 없습니다 (암호가 암호화됨)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 암호가 너무 짧습니다. 최소 %d자 이어야 합니다."
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "패키지 '%s'이/가 설치할 패키지 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "패키지 '%s'이/가 제외된 패키지 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "시작시 Kdump가 비활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "시작시 Kdump가 활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "시작시 방화벽이 비활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "시작시 방화벽이 활성화됩니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에 추가할 서비스 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "포트 '%s'이/가 방화벽에 추가할 포트 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "트러스트 '%s'이/가 방화벽에 추가할 트러스트 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에서 제거할 서비스 목록에 추가되었습니다. "
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠 가져오기 및 로딩 중 오류가 발생했습니다.:\n"
+"%s\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠에 대한 무결성 검사에 실패했습니다.\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "보안 정책(_S):"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "준비되어 있지 않습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "컨텐츠 데이터를 가져오는 중 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "프로파일이 선택되지 않았습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "사전 설치 단계의 규칙이 없습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "잘못된 내용이 입력되었습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "유효하지 않거나 지원되지 않는 컨텐츠 URL입니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "컨텐츠를 가져오지 못했습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "컨텐츠를 가져오는 중 네트워크 오류가 발생했습니다. 네트워크가 제대로 작동하는지 확인하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "컨텐츠 무결성 검사에 실패했습니다. 컨텐츠를 사용할 수 없습니다. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "컨텐츠 (%s)을/를 가져오지 못했습니다. 다른 URL을 입력하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID '%s'이/가 프로파일에 정의되어 있지 않습니다. 다른 프로파일을 선택하십시오. "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "보안 정책을 적용하지 않음 "
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "데이터 스트림 컨텐츠를 입력하거나 다음 URL을 아카이브하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "내용이 없습니다. 데이터 스트림 컨텐츠를 입력하거나 또는 다음 URL을 아카이브하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "컨텐츠 오류 가져오기 및 로딩 오류 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "컨텐츠를 찾을 수 없음 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "설정 오류가 감지되었습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "경고가 표시되었습니다 "
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "모든 것이 정상입니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "유효하지 않거나 지원되지 않는 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "컨텐츠 가져오는 중..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "보안 정책 "
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "컨텐츠 변경(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "보안 정책 적용:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "데이터 스트림:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "검사 목록:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "프로파일 선택: "
+
+# auto translated by TM merge from project: RHOSP Director Installation and
+# Usage , version: 11-Korean, DocId: master
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "프로파일"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "선택됨 "
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "프로파일 선택(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "완료된 변경사항 또는 필요한 변경사항:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP 보안 가이드 사용(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "가져오기(_F)"

--- a/rhel7-branch/oscap-anaconda-addon.pot
+++ b/rhel7-branch/oscap-anaconda-addon.pot
@@ -1,0 +1,271 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-27 15:53+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:199
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:347
+msgid "Fetching content data"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:614
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1015
+msgid "No profile selected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:619
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:757
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:765
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:773
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:781
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:790
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:816
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile, "
+"please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:832
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:863
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:867
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1005
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1012
+msgid "No content found"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1023
+msgid "Misconfiguration detected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1031
+msgid "Everything okay"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1107
+msgid "Invalid or unsupported URL"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1113 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr ""
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr ""
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr ""
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr ""
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr ""
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr ""
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr ""
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr ""

--- a/rhel7-branch/pl.po
+++ b/rhel7-branch/pl.po
@@ -1,0 +1,310 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Bartosz Sapijaszko <bartosz@sapek.net>, 2002
+# dcantrel <dcantrell@redhat.com>, 2011
+# Dimitris Glezos <glezos@indifex.com>, 2011
+# Dimitris Glezos <glezos@transifex.com>, 2011
+# Jacek Smyda <smyda@posexperts.com.pl>, 1998
+# Leszek Matok <lam@lac.pl>, 2004
+# Pawel Szopinski <pawel@szopinski.co.uk>, 2004
+# Piotr Drąg <piotrdrag@gmail.com>, 2014
+# Radosław Zawartko <radzaw@radzaw.one.pl>, 2004
+# sonyam <sonyam@tlen.pl>, 2004
+# Stanisław Małolepszy <smalolepszy@aviary.pl>, 2006
+# Tom Berner <tom@lodz.pl>, 2005
+# Tom Berner <tom@man.lodz.pl>, 2004
+# Wojciech Kapusta <wojciech@aviary.pl>, 2006
+# Piotr Drąg <piotrdrag@gmail.com>, 2015. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2017. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2018. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2020-06-27 05:24-0400\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
+"Language-Team: Polish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pl/)\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musi być na oddzielnej partycji lub woluminie logicznym i musi być "
+"utworzone w układzie partycjonowania, zanim można przeprowadzić instalację "
+"za pomocą profilu bezpieczeństwa"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"dodano opcję montowania \"%(mount_option)s\" dla punktu montowania "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "proszę się upewnić, że tworzone hasło ma co najmniej %d znaków"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "nie można sprawdzić długości hasła roota (hasło jest zaszyfrowane)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"hasło roota jest za krótkie, wymagane jest dłuższe z co najmniej %d znakami"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "dodano pakiet \"%s\" do listy pakietów do zainstalowania"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "dodano pakiet \"%s\" do listy wykluczonych pakietów"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump będzie wyłączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump będzie włączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Zapora sieciowa będzie wyłączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Zapora sieciowa będzie włączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "dodano usługę \"%s\" do listy usług do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "dodano port \"%s\" do listy portów do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "dodano zaufanie \"%s\" do listy zaufań do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "dodano usługę \"%s\" do listy usług do usunięcia z zapory sieciowej"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Wystąpił błąd podczas pobierania i wczytywania treści bezpieczeństwa:\n"
+"%s\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Sprawdzenie spójności treści bezpieczeństwa się nie powiodło.\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_ZASADY BEZPIECZEŃSTWA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Niegotowe"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Pobieranie danych treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Nie wybrano profilu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Brak reguł dla fazy przedinstalacyjnej"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Podano nieprawidłową treść. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Nieprawidłowy lub nieobsługiwany adres URL treści, proszę wybrać inny."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Pobranie treści się nie powiodło. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Wystąpił błąd sieci podczas pobierania danych. Proszę sprawdzić, czy sieć "
+"została ustawiona i działa poprawnie."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Sprawdzenie integralności treści się nie powiodło. Nie można użyć treści."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Wydobycie treści się nie powiodło (%s). Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"W treści nie określono profilu o identyfikatorze \"%s\". Proszę wybrać inny "
+"profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Bez zastosowywania zasad bezpieczeństwa"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" albo podać treść strumienia danych lub podać adres URL archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nie odnaleziono treści. Proszę podać treść strumienia danych lub adres URL "
+"archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Błąd podczas pobierania i wczytywania treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Nie odnaleziono treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Wykryto błędną konfigurację"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Pojawiły się ostrzeżenia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Wszystko jest w porządku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Nieprawidłowy lub nieobsługiwany adres URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Pobieranie treści..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ZASADY BEZPIECZEŃSTWA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Zmień treść"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Zastosowanie zasad bezpieczeństwa:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Strumień danych:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista do sprawdzenia:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Proszę wybrać profil poniżej:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Wybrane"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wybierz profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Wprowadzone zmiany i zmiany, które muszą zostać wprowadzone:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Użycie przewodnika bezpieczeństwa SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Pobierz"

--- a/rhel7-branch/pt.po
+++ b/rhel7-branch/pt.po
@@ -1,0 +1,268 @@
+# Manuela Silva <mmsrs@sky.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2015-09-12 01:40-0400\n"
+"Last-Translator: Manuela Silva <mmsrs@sky.com>\n"
+"Language-Team: Portuguese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "A obter dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Erro ao obter e carregar o conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Detetada má configuração"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Está tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "O obter o conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Alterar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr ""
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr ""
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr ""
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr ""
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr ""

--- a/rhel7-branch/pt_BR.po
+++ b/rhel7-branch/pt_BR.po
@@ -1,0 +1,306 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Marcelo Barbosa <firemanxbr@fedoraproject.org>, 2014
+# Marco Aurélio Krause <ouesten@me.com>, 2016. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:25-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pt_BR/)\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve estar em uma partição separada ou em um volume lógico e deve ser "
+"criado no layout de particionamento antes que a instalação possa ocorrer com"
+" um perfil de segurança"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opção de montagem '%(mount_option)s' adicionado para o ponto de montagem "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"certifique-se de criar uma senha com comprimento mínimo de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Não é possível verificar o comprimento da senha do root (senha "
+"criptografada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"A senha root é muito curta, uma mais longa com pelo menos %d caracteres são "
+"obrigatórios"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacote '%s' foi adicionado à lista de pacotes a serem instalados"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacote '%s' foi adicionado a lista de pacotes a serem excluídos"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "O Kdump será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "O Kdump será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem adicionados ao "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"port '%s'foi adicionado à lista de portas a serem adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"Confiar em '%s'foi adicionado à lista de relações de confiança a serem "
+"adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem removidos do firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ocorreu um erro ao buscar e carregar o conteúdo de segurança:\n"
+"%s\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"A verificação de integridade do conteúdo de segurança falhou.\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_POLÍTICA DE SEGURANÇA"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Ainda não esta pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Buscando dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Não há regras para a fase de pré-instalação"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Conteúdo fornecido é inválido. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL do conteúdo inválido ou não suportado, entre com um outro diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Falha ao buscar conteúdo. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Foi encontrado um erro na rede ao buscar dados. Verifique se a rede está "
+"configurada e funcionando."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"A verificação de integridade do conteúdo falhou. Não é possível usar o "
+"conteúdo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Falha ao extrair o conteúdo (%s). Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Perfil com ID '%s' não definido no conteúdo. Selecione um perfil diferente, "
+"por favor"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Não aplicar a política de segurança"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "ou inserir conteúdo de fluxo de dados ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenhum conteúdo encontrado. Por favor entre com conteúdo de fluxo de dados "
+"ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Erro ao buscar e carregar o conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Misconfiguration detectado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Advertências surgidas"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "URL inválida ou não suportada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Buscando conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Mudar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicar política de segurança:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Fluxo de dados:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Escolha o perfil abaixo:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selecionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecione o perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "As alterações que foram feitas ou precisam ser feitas:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Use SCAP Segurança Guia"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Buscar"

--- a/rhel7-branch/ru.po
+++ b/rhel7-branch/ru.po
@@ -1,0 +1,294 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-02-12 02:29-0500\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} должен быть на отдельном разделе или логическом томе и должен быть "
+"создан в макете разбиения до того, как установка может произойти с профилем "
+"безопасности"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"mount option '%(mount_option)s'добавлен для точки монтирования "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "не забудьте создать пароль с минимальной длиной %d персонажи"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "не удается проверить длину пароля root (пароль зашифрован)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"пароль root слишком короткий, более длинный с по крайней мере %d требуется "
+"персонаж"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s'добавлен в список установленных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s'добавлен в список исключенных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "Брандмауэр будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "Брандмауэр будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"порт '%s'добавлен в список портов, которые будут добавлены в брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"доверие \"%s'добавлен в список доверенностей, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые необходимо удалить из "
+"брандмауэра"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ошибка получения и загрузки содержимого безопасности:%sУстановка должна быть"
+" прервана. Вы все равно хотите продолжить?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Не удалось проверить целостность содержимого безопасности. Установка должна "
+"быть прервана. Вы все равно хотите продолжить?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_ПОЛИТИКА БЕЗОПАСНОСТИ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Не готов"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Получение данных контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Не выбран профиль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Нет правил для этапа предварительной установки"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Недопустимый контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Неверный или неподдерживаемый URL-адрес контента, введите другой."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не удалось получить контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Ошибка сети при сборе данных. Убедитесь, что сеть настроена и работает."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Не удалось проверить целостность содержимого. Невозможно использовать "
+"контент."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Не удалось извлечь контент (%s). Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профиль с идентификатором '%s'не определено в контенте. Выберите другой "
+"профиль, пожалуйста"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Не применять политику безопасности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr " или введите содержимое потока данных или URL-адрес архива ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Контент не найден. Введите содержимое потока данных или URL-адрес архива "
+"ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Ошибка получения и загрузки содержимого"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Не найдено ни одного контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Обнаружено несоответствие"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Появились предупреждения"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Все в порядке"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Недействительный или неподдерживаемый URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Получение контента ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПОЛИТИКА БЕЗОПАСНОСТИ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Изменить контент"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Применение политики безопасности:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Поток данных:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Контрольный список:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Выберите профиль ниже:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профиль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "выбранный"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Выбрать профиль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Изменения, которые были сделаны или должны быть выполнены:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Используйте руководство по безопасности SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Получить"

--- a/rhel7-branch/sr.po
+++ b/rhel7-branch/sr.po
@@ -1,0 +1,278 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Momcilo Medic <medicmomcilo@gmail.com>, 2014
+# Momcilo Medic <medicmomcilo@gmail.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2015-04-18 01:39-0400\n"
+"Last-Translator: Momcilo Medic <medicmomcilo@gmail.com>\n"
+"Language-Team: Serbian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/sr/)\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"прикључна опција '%(mount_option)s' додата за прикључну тачку "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "изаберите шифру од најмање %d карактера"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "немогуће проверити дужину root шифре (шифра је криптована)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s' је додат на листу пакета за инсталацију"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s' је додат на листу искључених пакета"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "_БЕЗБЕДНОСНИ МОДЕЛ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Није спремно"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Преузимање података о садржају"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Није изабран профил"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Нема правила за пред-инсталациону фазу"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Неисправан садржај пружен. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Неуспешно преузимање садржаја. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Неуспешно извлачење садржаја (%s). Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Не примењујем полису безбедности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "или унесите садржајни или архивски URL за stream података испод:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Садржај није пронађен. Молим унесите садржајни или архивски URL за stream "
+"података:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Садржај није пронађен"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Погрешно подешавање откривено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Упозорења су се појавила"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Све је у реду"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Неисправан или неподржан URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Преузимање садржаја..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "БЕЗБЕДНОСНИ МОДЕЛ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Промена садржаја"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Примени сигурносну политику:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Stream података:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Листа:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Изаберите профил:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профил"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Изабрано"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Изаберите профил"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Промене које су урађене или требају да се ураде:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Користи SCAP сигурносни водич"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Преузми"

--- a/rhel7-branch/uk.po
+++ b/rhel7-branch/uk.po
@@ -1,0 +1,283 @@
+# Yuri Chornoivan <yurchor@ukr.net>, 2015.
+# Yuri Chornoivan <yurchor@ukr.net>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2015-08-31 03:22-0400\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"для точки монтування %(mount_point)s додано параметр монтування "
+"«%(mount_option)s»"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "довжина пароля має бути не меншою за %d символів"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "не вдалося перевірити довжину пароля root (пароль зашифровано)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "до списку встановлюваних пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "до списку виключених пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Під час отримання та завантаження даних захисту сталася помилка:\n"
+"%s\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Дані захисту не пройшли перевірку на цілісність.\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "П_РАВИЛА ЗАХИСТУ"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "Неготовий"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "Отримуємо дані"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "Не вибрано жодного профілю"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "Правил для кроку перед встановленням немає"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Надано некоректні дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Некоректна або непідтримувана адреса даних. Будь ласка, введіть якусь іншу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не вдалося отримати дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Під час спроби отримання даних сталася помилка, пов’язана із мережею. Будь "
+"ласка, перевірте, чи правильно налаштовано з’єднання, та чи є воно "
+"працездатним."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Дані не пройшли перевірку на цілісність. Їхнє використання неможливе."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Не вдалося видобути дані (%s). Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профіль з ідентифікатором «%s» у даних не визначено. Виберіть, будь ласка, "
+"інший профіль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "Не застосовуємо правил захисту"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr " або вкажіть адресу потоку даних чи архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Даних не знайдено. Будь ласка, вкажіть адресу потоку даних або архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "Помилка під час спроби отримання та завантаження даних"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "Даних не знайдено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "Виявлено помилки у налаштуваннях"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "Отримано попередження"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "Все гаразд"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "Некоректна або непідтримувана адреса"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "Отримуємо дані…"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПРАВИЛА ЗАХИСТУ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "З_міна даних"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Застосувати правило захисту:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Потік даних:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Список для перевірки:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Виберіть профіль:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профіль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Позначене"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Вибрати профіль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Зміни, які внесено або має бути внесено:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "Ви_користати настанови із захисту SCAP"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "_Отримати"

--- a/rhel7-branch/zh_CN.po
+++ b/rhel7-branch/zh_CN.po
@@ -1,0 +1,273 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2018-11-21 12:15-0500\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Chinese (Simplified)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必须在一个独立的分区或逻辑卷上，并需要在带有安全档案的安装进行前，在分区布局中创建"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "为挂载点 %(mount_point)s 添加的挂载选项 '%(mount_option)s'"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "确保创建的密码长度最少为 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "无法检查 root 密码的长度（密码已加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 密码太短，它需要最少包括 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "软件包 '%s' 已被添加到要被安装的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "软件包 '%s' 已被添加到排除的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump 将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump 将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "防火墙将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "防火墙将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要加到防火墙的服务列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "端口 '%s' 已被添加到要加到防火墙的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任 '%s' 已被添加到要加到防火墙的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要从防火墙删除的服务列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"在获取和加载安全内容时出错：\n"
+"%s\n"
+"安装应该被终止。您希望继续吗？"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"对安全内容的完整性检查失败。\n"
+"安装应该被终止。您希望继续吗？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "安全策略（_S）："
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "未就绪"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "获取内容数据"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "没有选择 profile"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "没有预安装阶段的规则"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供无效的内容。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "无效或不支持的内容 URL，请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "获取内容失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "在获取数据时出现网络错误。请检查网络是否正常。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "内容的完整性检查失败。不能使用这个内容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "提取内容 (%s) 失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID 为 '%s' 的档案没有在内容中定义。请选择一个不同的档案"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "没有应用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr "或输入数据流内容或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "没有找到内容。请输入数据流或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "获取并加载内容错误"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "没有找到内容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "发现错误配置"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "出现的警告"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "一切正常"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "无效或不支持的 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "获取内容..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全策略"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "修改内容(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "应用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "数据流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "检查列表："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "选择档案："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "档案"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "选择"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "选择档案(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的改变"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "使用 SCAP 安全指南(_U)"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "获取(_F)"

--- a/rhel7-branch/zh_TW.po
+++ b/rhel7-branch/zh_TW.po
@@ -1,0 +1,268 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-06-04 14:37+0200\n"
+"PO-Revision-Date: 2019-01-15 11:43-0500\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:392
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必須位於單獨的分區或邏輯卷上，並且必須在分區佈局中創建，然後才能使用安全配置文件進行安裝"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:403
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "掛載選項'%(mount_option)s'為掛載點添加了 %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:502
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "確保以最小的長度創建密碼 %d 人物"
+
+#: ../org_fedora_oscap/rule_handling.py:509
+msgid "cannot check root password length (password is crypted)"
+msgstr "無法檢查root密碼長度（密碼被加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:515
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root密碼太短，至少有一個 %d 字符是必需的"
+
+#: ../org_fedora_oscap/rule_handling.py:617
+#: ../org_fedora_oscap/rule_handling.py:632
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "包'%s'已添加到要安裝的軟件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:641
+#: ../org_fedora_oscap/rule_handling.py:656
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "包'%s'已添加到已排除的包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:754
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump將在啟動時被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:756
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:903
+msgid "Firewall will be disabled on startup"
+msgstr "防火牆將在啟動時禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:910
+msgid "Firewall will be enabled on startup"
+msgstr "防火牆將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:918
+#: ../org_fedora_oscap/rule_handling.py:955
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服務'%s'已添加到要添加到防火牆的服務列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:925
+#: ../org_fedora_oscap/rule_handling.py:966
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "港口 '%s'已被添加到要添加到防火牆的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:932
+#: ../org_fedora_oscap/rule_handling.py:977
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任'%s'已被添加到要添加到防火牆的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:986
+#: ../org_fedora_oscap/rule_handling.py:1001
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服務'%s'已被添加到要從防火牆中刪除的服務列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:423
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "獲取和加載安全內容時出錯：%s安裝應該中止。你想繼續嗎？"
+
+#: ../org_fedora_oscap/ks/oscap.py:452
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "安全內容的完整性檢查失敗。安裝應該中止。你想繼續嗎？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:172
+msgid "_SECURITY POLICY"
+msgstr "安全政策（_S）"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:197
+msgid "Not ready"
+msgstr "沒有準備好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:345
+msgid "Fetching content data"
+msgstr "獲取內容數據"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:612
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1013
+msgid "No profile selected"
+msgstr "沒有選擇個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:617
+msgid "No rules for the pre-installation phase"
+msgstr "沒有預安裝階段的規則"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:755
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供的內容無效。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:763
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "無效或不受支持的內容網址，請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:771
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "無法獲取內容。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:779
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "獲取數據時遇到網絡錯誤。請檢查網絡是否已設置並正常運行。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:788
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "內容的完整性檢查失敗。無法使用內容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:796
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "無法提取內容（%s）。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "帶ID的個人資料'%s'沒有在內容中定義。請選擇其他個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:830
+msgid "Not applying security policy"
+msgstr "不應用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:861
+msgid " or enter data stream content or archive URL below:"
+msgstr " 或輸入以下數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:865
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "找不到任何內容。請在下面輸入數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1003
+msgid "Error fetching and loading content"
+msgstr "獲取和加載內容時出錯"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1010
+msgid "No content found"
+msgstr "找不到任何內容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1021
+msgid "Misconfiguration detected"
+msgstr "檢測到配置錯誤"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1027
+msgid "Warnings appeared"
+msgstr "警告出現了"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1029
+msgid "Everything okay"
+msgstr "一切都好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1105
+msgid "Invalid or unsupported URL"
+msgstr "網址無效或不受支持"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1111 tmp/oscap.glade.h:13
+msgid "Fetching content..."
+msgstr "獲取內容......"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全政策"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "改變內容（_C）"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "應用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "數據流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "清單："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "選擇以下資料："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "輪廓"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "選擇個人資料（_S）"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的更改："
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_使用SCAP安全指南（_U）"
+
+#: tmp/oscap.glade.h:12
+msgid "_Fetch"
+msgstr "取（_F）"

--- a/rhel8-branch/ca.po
+++ b/rhel8-branch/ca.po
@@ -1,0 +1,308 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Robert Antoni Buj i Gelonch <rbuj@fedoraproject.org>, 2015
+# Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2015-09-29 07:31-0400\n"
+"Last-Translator: Robert Antoni Buj Gelonch <rbuj@fedoraproject.org>\n"
+"Language-Team: Catalan (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/ca/)\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"l'opció de muntatge '%(mount_option)s' va afegir-se al punt de muntatge "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assegureu-vos de crear una contrasenya amb una mida mínima de %d caràcters"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no es pot comprovar la mida de la contrasenya de root (la contrasenya està "
+"xifrada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets instal·lats"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "el paquet «%s» s'ha afegit a la llista dels paquets exclosos"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Hi va haver un error en la captura i la càrrega del contingut de seguretat:\n"
+"%s\n"
+"S'hauria d'avortar la instal·lació. Voleu continuar de totes maneres?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ha fallat la comprovació de la integritat del contingut de seguretat.\n"
+"S'hauria d'avortar la instal·lació. Voleu continuar de totes maneres?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "No està llest"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "S'estan obtenint les dades del contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "No s'ha seleccionat cap perfil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Sense regles per a la fase de pre-instal·lació"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"S'ha proporcionat un context no vàlid. Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"L'URL del contingut no és vàlid o no està admès, si us plau, introduïu-ne un"
+" altre diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"L'obtenció del contingut ha fallat. Si us plau, introduïu un URL diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"S'ha detectat un error de xarxa quan es capturaven les dades. Reviseu que la"
+" xarxa estigui configurada i que aquesta estigui funcionant."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Ha fallat la comprovació de la integritat del contingut. No es pot utilitzar"
+" el contingut."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"L'extracció del contingut ha fallat (%s). Si us plau, introduïu un URL "
+"diferent."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"El perfil amb l'id. «%s» no està definit en el contingut. Seleccioneu un "
+"perfil diferent, si us plau"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Sense aplicar la política de seguretat"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"A continuació introduïu el contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No s'ha trobat cap contingut. Si us plau, a continuació introduïu el "
+"contingut del flux de dades o l'URL de l'arxiu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "S'ha produït un error en capturar i carregar el contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "No s'ha trobat cap contingut"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "S'ha detectat una configuració errònia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Advertències que van aparèixer"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Tot està bé"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "L'URL no és vàlid o no està admès"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "S'està obtenint el contingut..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURETAT"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Canvia el contingut"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplica la política de seguretat:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de dades:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Llista de comprovació:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Trieu el perfil a sota:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionat"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecciona el perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Els canvis que es van fer o s'han de fer:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utilitza la guia de seguretat SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Obté"

--- a/rhel8-branch/cs.po
+++ b/rhel8-branch/cs.po
@@ -1,0 +1,300 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# vpodzime <vpodzime@redhat.com>, 2014-2015
+# Zdenek <chmelarz@gmail.com>, 2016. #zanata
+# Zdenek <chmelarz@gmail.com>, 2017. #zanata
+# Daniel Rusek <mail@asciiwolf.com>, 2018. #zanata
+# Matěj Týč <matyc@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-22 05:42-0400\n"
+"Last-Translator: Matěj Týč <matyc@redhat.com>\n"
+"Language-Team: Czech (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/cs/)\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musí být na samostatném diskovém nebo logickém oddílu a musí být "
+"vytvořen v rozdělení oddílů předtím, než bude moci být zahájena instalace s "
+"bezpečnostním profilem"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "parametr '%(mount_option)s' přidán pro přípojný bod %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "ujistěte se, že heslo bude mít minimální délku %d znaků"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "nelze zkontrolovat délku hesla uživatele root (heslo je šifrováno)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"heslo uživatele root je příliš krátké, je vyžadováno delší heslo s nejméně "
+"%d znaky"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "balík '%s' byl přidán do seznamu instalovaných balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, fuzzy, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+"balík '{package}' byl přidán do seznamu vyloučených balíků, ale nelze jej "
+"odebrat ze zvoleného výběru softwaru zvoleného pro intsalaci."
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "balík '%s' byl přidán do seznamu vyloučených balíků"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall bude při spuštění zakázán"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall bude při spuštění povolen"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port '%s' byl přidán na seznam portů k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "důvěra '%s' byla přidána na seznam důvěr k přidání do firewallu"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "služba '%s' byla přidána na seznam služeb k odebrání z firewallu"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Při získávání a načítání bezpečnostních dat došlo k chybě:\n"
+"%s\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Test integrity bezpečnostních dat neprošel.\n"
+"Instalace by měla být přerušena. Chcete i přesto pokračovat?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Politika zabezpečení"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Není připraven"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Načítají se data"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Není vybrán žádný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Žádná pravidla pro předinstalační fázi"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Nevalidní data. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Nevalidní nebo nepodporované datové URL, zadejte prosím jiné."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Načítání dat selhalo. Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Během získávání dat se vyskytla chyba sítě. Zkontrolujte prosím, že je síť "
+"nastavena a funkční."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Test integrity dat neprošel. Nelze použít tato data."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Rozbalování dat selhalo (%s). Zadejte jiné URL, prosím."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "Profil s ID '%s' není definován v datech. Vyberte prosím jiný profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Neaplikovat bezpečnostní politiku"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "nebo zadejte URL data streamu, případně archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenalezen žádný zdroj dat. Prosím uveďte URL k data streamu nebo archivu:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Chyba při získávání a načítání dat"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Žádná data k dispozici"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Detekována nesprávná konfigurace"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Varování"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Vše v pořádku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Nevalidní nebo nepodporované URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Načítám data..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIKA ZABEZPEČENÍ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Jiná data"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplikovat bezpečnostní politiku:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Data stream:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Vyberte profil:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Vybrán"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Vybrat profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Změny, které byly nebo musejí být provedeny:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Použít SCAP Security Guide"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Načíst"

--- a/rhel8-branch/de.po
+++ b/rhel8-branch/de.po
@@ -1,0 +1,315 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-30 10:55-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} muss sich auf einer separaten Partition oder einem logischen Volume "
+"befinden und muss im Partitionslayout erstellt werden, bevor die "
+"Installation mit einem Sicherheitsprofil erfolgen kann"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"Einhängeoption '%(mount_option)s'hinzugefügt für den Einhängepunkt "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Stellen Sie sicher, dass Sie ein Kennwort mit einer Mindestlänge von "
+"erstellen %d Zeichen"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Länge des Root-Passworts kann nicht geprüft werden (Passwort wird "
+"verschlüsselt)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"Das root-Passwort ist zu kurz, ein längeres mit mindestens %d Zeichen sind "
+"erforderlich"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "Paket \"%s'wurde der Liste der zu installierenden Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "Paket \"%s'wurde der Liste der ausgeschlossenen Pakete hinzugefügt"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Die Firewall wird beim Start deaktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Die Firewall wird beim Start aktiviert"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die zur Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"Hafen '%s'wurde der Liste der Ports hinzugefügt, die der Firewall "
+"hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"vertrauen '%s'wurde der Liste der Vertrauensstellungen hinzugefügt, die der "
+"Firewall hinzugefügt werden sollen"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"Bedienung '%s'wurde der Liste der Dienste hinzugefügt, die aus der Firewall "
+"entfernt werden sollen"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Beim Abrufen und Laden des Sicherheitsinhalts ist ein Fehler "
+"aufgetreten:%sDie Installation sollte abgebrochen werden. Möchten Sie "
+"trotzdem fortfahren?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Die Integritätsprüfung des Sicherheitsinhalts ist fehlgeschlagen. Die "
+"Installation sollte abgebrochen werden. Möchten Sie trotzdem fortfahren?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Sicherheitspolitik"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Nicht bereit"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Inhaltsdaten abrufen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Kein Profil ausgewählt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Keine Regeln für die Vorinstallationsphase"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Ungültiger Inhalt bereitgestellt Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Ungültige oder nicht unterstützte Inhalts-URL. Bitte geben Sie eine andere "
+"URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht abgerufen werden. Bitte geben Sie eine andere URL ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Beim Abrufen von Daten ist ein Netzwerkfehler aufgetreten. Bitte überprüfen "
+"Sie, ob das Netzwerk eingerichtet ist und funktioniert."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Die Integritätsprüfung des Inhalts ist fehlgeschlagen. Der Inhalt kann nicht"
+" verwendet werden."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Inhalt konnte nicht extrahiert werden (%s). Bitte geben Sie eine andere URL "
+"ein."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profil mit ID '%s'im Inhalt nicht definiert. Bitte wählen Sie ein anderes "
+"Profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Keine Sicherheitsrichtlinie anwenden"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr " oder geben Sie den Datenstrominhalt oder die Archiv-URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Kein Inhalt gefunden Bitte geben Sie den Datenstrom-Inhalt oder die Archiv-"
+"URL unten ein:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Fehler beim Abrufen und Laden von Inhalten"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Kein Inhalt gefunden"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Fehlkonfiguration erkannt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Warnungen erschienen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Alles okay"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Ungültige oder nicht unterstützte URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Inhalt wird abgerufen ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "SICHERHEITSPOLITIK"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Ändern Sie den Inhalt"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Sicherheitsrichtlinie anwenden:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Datenstrom:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checkliste:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Wählen Sie unten ein Profil:"
+
+#: tmp/oscap.glade.h:7
+#, fuzzy
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+#, fuzzy
+msgid "Selected"
+msgstr "Ausgewählt"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wähle Profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Änderungen, die vorgenommen wurden oder durchgeführt werden müssen:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Verwenden Sie das SCAP-Sicherheitshandbuch"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Fetch"

--- a/rhel8-branch/es.po
+++ b/rhel8-branch/es.po
@@ -1,0 +1,320 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Gerardo Rosales <grosale86@gmail.com>, 2014
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2016. #zanata
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2017. #zanata
+# Máximo Castañeda Riloba <mcrcctm@gmail.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-30 10:53-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Spanish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/es/)\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} debe estar en una partición separada o en un volumen lógico y debe "
+"crearse en el diseño de particiones antes de que se inicie la instalación "
+"con un perfil de seguridad"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opciones de montaje '%(mount_option)s' añadidas para el punto de montaje "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"Asegúrese de crear una contraseña con una longitud mínima de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"no se puede comprobar la longitud de la contraseña raíz(la contraseña está "
+"encriptada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la contraseña de root es demasiado corta, se exige una más larga con al "
+"menos %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes a instalar"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "paquete '%s' se ha añadido a la lista de paquetes excluidos"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Se desactivará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Se activará Kdump al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Se desactivará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Se activará el cortafuegos al inicio"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a añadir al "
+"cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"el puerto '%s' se ha añadido a la lista de puertos a añadir al cortafuegos"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"confiar%s'se ha agregado a la lista de fideicomisos que se agregarán al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"el servicio '%s' se ha añadido a la lista de servicios a quitar del "
+"cortafuegos"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Se produjo un error al obtener y cargar el contenido de seguridad:\n"
+"%s\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Falló la comprobación de integridad del contenido de seguridad.\n"
+"Debería pararse la instalación. ¿Quiere continuar de todas formas?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Política de Seguridad"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "No está listo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Obteniendo datos de contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Ningún perfil seleccionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Ninguna regla para la fase de pre-instalación"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Contenido proporcionado inválido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"La URL del contenido no es válida o no está admitida, por favor introduzca "
+"una nueva."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Falló la obtención de contenido. Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Se produjo un error de red al obtener los datos. Compruebe que la red está "
+"configurada y en funcionamiento."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Falló la comprobación de la integridad del contenido. No se puede usar el "
+"mismo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Fallo al extraer el contenido(%s). Ingrese una URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"El perfil con ID '%s' no está definido en el contenido. Elija uno diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "No se aplica política de seguridad"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+"o ingrese el contenido de flujo de datos o archivo URL a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"No se encontró contenido. Por favor ingrese un contenido de flujo de datos o"
+" un archivo a continuación:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Error al obtener y cargar el contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "No se encontró contenido"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Configuración errónea detectada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Advertencias aparecieron"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Todo está bien"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "URL no soportada o es inválida"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Obteniendo contenido..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURIDAD"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambiando contenido"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicando política de seguridad:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flujo de datos:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista de comprobación:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Elija un perfil a continuación:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Seleccionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleccionar perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Cambios que fueron o serán hechos:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usar Guía de seguridad SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Obtener"

--- a/rhel8-branch/fr.po
+++ b/rhel8-branch/fr.po
@@ -1,0 +1,320 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# dominique bribanick <chepioq@gmail.com>, 2014
+# Jérôme Fenal <jfenal@gmail.com>, 2014
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-26 04:26-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: French (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/fr/)\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} doit être sur une partition ou un volume logique séparé et doit être "
+"créé dans la structure de partitionnement avant que l'installation puisse "
+"avoir lieu avec un profil de sécurité"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"option de montage « %(mount_option)s » ajoutée au point de montage "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assurez-vous de créer un mot de passe d'une longueur minimale de %d "
+"caractères"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossible de vérifier la longueur du mot de passe de root (mot de passe "
+"chiffré)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"le mot de passe de root est trop court, une longueur d'au moins %d "
+"caractères est requise"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à installer"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+"le paquet {package}été ajouté à la liste des paquets exclus, mais il ne peut"
+" pas être retiré de la sélection actuelle des logiciels sans interrompre "
+"l'installation."
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "le paquet « %s » a été ajouté à la liste des paquets à exclure"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Le pare-feu va être désactivé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Le pare-feu va être activé au démarrage"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"trust « %s » a été ajouté à la liste des paquets à ajouter au pare-feu"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"service « %s » a été ajouté à la liste des paquets à retirer du pare-feu"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il y a eu une erreur lors de l'extraction et du chargement du contenu de sécurité :\n"
+"%s\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Le contrôle d'intégrité du contenu de sécurité a échoué.\n"
+"L'installation doit être interrompue. Souhaitez-vous continuer quand même ?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Politique de sécurité"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Pas prêt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Récupération des données de contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Aucun profil sélectionné"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Aucune règle pour la phase de pré-installation"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenu fourni invalide. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL de contenu non prise en charge ou non valide, veuillez saisir une URL "
+"différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Échec de la récupération du contenu. Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Erreur de réseau lors de l'extraction des données. Veuillez vérifier que le "
+"réseau ait été installé et fonctionne correctement."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Le contrôle d'intégrité du contenu a échoué. Impossible d'utiliser le "
+"contenu."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossible d'extraire le contenu (%s). Merci de saisir une URL différente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Le profil ayant pour ID « %s »n'est pas défini dans le contenu. Sélectionner"
+" un autre profil, s'il vous plaît"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "N'applique pas la politique de sécurité"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" ou saisir un flux de données de contenu ou l'URL d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Contenu introuvable. Merci de saisir un flux de données de contenu ou l'URL "
+"d'une archive ci-dessous :"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Erreur d'extraction et de chargement du contenu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Contenu introuvable"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Mauvaise configuration détectée"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Des avertissements sont apparus"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Tout est OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "URL invalide ou non prise en charge"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Récupération du contenu..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITIQUE DE SÉCURITÉ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Modifier le contenu"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Application de la politique de sécurité :"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flux de données :"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Liste de vérifications :"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Choisir le profil ci-dessous :"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Sélectionné"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Sélectionner le profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifications réalisées ou à faire :"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Utiliser le guide de sécurité SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Récupérer"

--- a/rhel8-branch/hu.po
+++ b/rhel8-branch/hu.po
@@ -1,0 +1,311 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Zoltan Hoppár <zoltanh721@fedoraproject.org>, 2014
+# Teknős Ferenc <teknos.ferenc@gmail.com>, 2018. #zanata
+# Teknős Ferenc <teknos.ferenc@gmail.com>, 2019. #zanata
+# Teknős Ferenc <teknos.ferenc@gmail.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-03-29 01:40-0400\n"
+"Last-Translator: Teknős Ferenc <teknos.ferenc@gmail.com>\n"
+"Language-Team: Hungarian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/hu/)\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"A {0} -nek külön partíción vagy logikai köteten kell lennie, és létre kell "
+"hoznia a particionálási elrendezésben, mielőtt a telepítés megtörténhet "
+"biztonsági profilon"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"a '%(mount_option)s' csatolási opció hozzáadásra került ehhez: "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "bizonyosodjon meg arról, hogy %d karakter hosszúságú jelszót ad meg"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "root jelszó hosszúsága nem ellenőrzhető (jelszó titkosított)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"root jelszó túl rövid, de hosszabbnak kell lennie legalább %d karakterrel"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "'%s' csomag hozzáadásra került a telepítendő csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "'%s' csomag hozzáadásra került az eltávolítandó csomagok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "A Kdump indításkor le lesz tiltva"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "A Kdump indításkor engedélyezve lesz"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "A tűzfal indításkor le lesz tiltva"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "A tűzfal engedélyezve lesz az indításkor"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"szolgáltatás \"%s\" lett hozzáadva a tűzfalhoz hozzáadandó szolgáltatások "
+"listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "port \"%s\" lett hozzáadva a tűzfalhoz hozzáadandó portok listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"a \"%s\" szolgáltatás hozzá lett adva a tűzfalhoz hozzáadandó megbízhatók "
+"listájához"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"szolgáltatás \"%s\" lett hozzáadva a tűzfalról eltávolítandó szolgáltatások "
+"listájához"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Hiba történt a biztonsági tartalom lekérése és betöltése során:\n"
+"%s\n"
+"A telepítést meg kell szakítani. Szeretné folytatni?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"A biztonsági tartalom integritásának ellenőrzése sikertelen.\n"
+"A telepítést meg kell szakítani. Szeretné folytatni?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Biztonsági házirend"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Nincs még kész"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Adatok letöltése"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Nincs profil kiválasztva"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Nincsenek szabályok felállítva az előkészítési fázishoz"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+"Helytelen tartalom került megadásra. Kérem, adjon meg egy másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Érvénytelen vagy nem támogatott tartalom URL, kérjük, írjon be másikat."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Tartalom letöltése sikertelen. Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Hálózati hiba történt az adatok lekérésekor. Ellenőrizze, hogy a hálózat "
+"beállítása és működése megfelelő."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Nem sikerült a tartalom integritásának ellenőrzése. A tartalom nem "
+"használható."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Tartalom kibontása sikertelen (%s). Kérem, adjon meg másik URL-t."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"A (z) \"%s\" azonosítójú profil nem szerepel a tartalomban. Kérem válasszon "
+"másik profilt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Nem alkalmazható a biztonsági házirend"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "vagy adjon meg adathalmazt, vagy archiv URL-t alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Tartalom nem található. Kérem adjon meg egy adathalmazt, vagy archív URL-t "
+"alább:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Hiba történt a tartalom lekérése és betöltése során"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Tartalom nem található"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Helytelen beállítások észlelve"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Figyelmeztetések jelentek meg"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Minden rendben"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Rossz vagy nem támogatott URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Tartalom letöltése..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "BIZTONSÁGI HÁZIREND"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "Tartalom megváltoztatása"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Biztonsági házirend alkalmazása:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Adathalmaz:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Ellenőrző lista:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Válasszon egy profilt alább:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Kiválasztva"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "Vála_sszon egy profilt"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Változtatások amiket meg kell tenni vagy elkészültek:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP Biztonsági könyv előírásainak használata"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "Letöltés"

--- a/rhel8-branch/it.po
+++ b/rhel8-branch/it.po
@@ -1,0 +1,310 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-30 10:54-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve essere su una partizione separata o su un volume logico e deve "
+"essere creato nel layout di partizionamento prima che l'installazione possa "
+"avvenire con un profilo di sicurezza"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opzione di montaggio%(mount_option)s'aggiunto per il punto di mount "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"assicurati di creare una password con una lunghezza minima di %d personaggi"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"impossibile controllare la lunghezza della password di root (la password è "
+"criptata)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"la password di root è troppo breve, più lunga con almeno %d i caratteri sono"
+" obbligatori"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti da installare"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacchetto '%s'è stato aggiunto all'elenco dei pacchetti esclusi"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Il firewall sarà disabilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Il firewall sarà abilitato all'avvio"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da aggiungere al "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"porto%s'è stato aggiunto all'elenco delle porte da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"fiducia '%s'è stato aggiunto all'elenco dei trust da aggiungere al firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"servizio '%s'è stato aggiunto all'elenco dei servizi da rimuovere dal "
+"firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Si è verificato un errore durante il recupero e il caricamento del contenuto"
+" di sicurezza:%sL'installazione dovrebbe essere interrotta. Vuoi continuare "
+"comunque?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Il controllo di integrità del contenuto di sicurezza non è riuscito. "
+"L'installazione dovrebbe essere interrotta. Vuoi continuare comunque?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Politica di Sicurezza"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Non pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Recupero dei dati di contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Nessun profilo selezionato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Nessuna regola per la fase di pre-installazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Contenuto non valido fornito. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "URL di contenuto non valido o non supportato, inserisci uno diverso."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+"Impossibile recuperare il contenuto. Inserisci un URL diverso, per favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Errore di rete rilevato durante il recupero dei dati. Si prega di verificare"
+" che la rete sia configurata e funzionante."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Il controllo di integrità del contenuto non è riuscito. Non posso usare il "
+"contenuto."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Impossibile estrarre il contenuto (%s). Inserisci un URL diverso, per "
+"favore."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profilo con ID '%s'non definito nel contenuto. Seleziona un profilo diverso,"
+" per favore"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Non applicare la politica di sicurezza"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" oppure inserisci il contenuto del flusso di dati o l'URL di archivio di "
+"seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nessun contenuto trovato. Inserisci il contenuto del flusso di dati o l'URL "
+"di archiviazione di seguito:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Errore durante il recupero e il caricamento del contenuto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Nessun contenuto trovato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Rilevata errata configurazione"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Sono apparsi avvertimenti"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Tutto ok"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "URL non valido o non supportato"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Recupero del contenuto ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITICA DI SICUREZZA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Cambia i contenuti"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Applica la politica di sicurezza:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Flusso di dati:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Elenco di controllo:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Scegli il profilo qui sotto:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profilo"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selezionato"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Seleziona profilo"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Modifiche che sono state fatte o devono essere fatte:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Usare Guida alla sicurezza di SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Ottenere"

--- a/rhel8-branch/ja.po
+++ b/rhel8-branch/ja.po
@@ -1,0 +1,287 @@
+# Ludek Janda <ljanda@redhat.com>, 2017. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-26 04:25-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} "
+"は、別のパーティションもしくは論理ボリューム上になければなりません。また、セキュリティープロファイルがインストールされる前にパーティションレイアウトに作成されなければなりません"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "マウントオプション '%(mount_option)s' が、マウントポイント %(mount_point)s に追加されました"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "%d 文字以上のパスワードを作成してください"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "root パスワードの長さを確認できません (パスワードは暗号化済み)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root のパスワードが短すぎます。%d 文字以上にする必要があります"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "パッケージ '%s' が、インストール予定パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+"パッケージ ' {package}' "
+"が除外パッケージのリストに追加されましたが、インストールを中断せずに現在のソフトウェアの選択から削除することはできません。"
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "パッケージ '%s' が、除外パッケージ一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump は起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump は起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "ファイアウォールは起動時に無効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "ファイアウォールは起動時に有効になります"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールに追加予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "ポート '%s' が、ファイアウォールに追加予定のポート一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "トラスト '%s' が、ファイアウォールに追加予定のトラスト一覧に追加されました"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "サービス '%s' が、ファイアウォールから削除予定のサービス一覧に追加されました"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの取得時およびロード時にエラーが発生しました。\n"
+"%s\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"セキュリティーコンテンツの整合性チェックに失敗しました。\n"
+"インストールを停止する必要があります。それでも続行しますか?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "セキュリティーポリシー(_S)"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "準備ができていません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "コンテンツデータの取得中"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "選択されたプロファイルはありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "プレインストールフェーズのルールがありません"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "無効なコンテンツが入力されました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "コンテンツ URL が無効またはサポートされていません。別の URL を入力していません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "コンテンツの取得に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "データの取得時にネットワークエラーが発生しました。ネットワークが設定されており、動作していることを確認してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "コンテンツの整合性チェックに失敗しました。コンテンツを使用できません。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "コンテンツ (%s) の抽出に失敗しました。別の URL を入力してください。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "コンテンツで ID が '%s' のプロファイルが定義されていません。別のプロファイルを選択してください"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "セキュリティーポリシーを適用しない"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "または、以下にデータストリームコンテンツもしくはアーカイブの URL を入力します:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "コンテンツが見つかりませんでした。以下にデータストリームコンテンツもしくはアーカイブの URL を入力してください:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "コンテンツの取得およびロードのエラー"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "コンテンツが見つかりませんでした"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "設定ミスが検出されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "警告が表示されました"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "すべて OK"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "無効またはサポートされていない URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "コンテンツの取得中..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "セキュリティーポリシー"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "コンテンツの変更(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "セキュリティーポリシーの適用:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "データストリーム:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "チェックリスト:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "以下のプロファイルを選択:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "プロファイル"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選択済み"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "プロファイルを選択(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "完了済みの変更または必要な変更:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP セキュリティーガイドを使用する(_U)"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "取得(_F)"

--- a/rhel8-branch/ko.po
+++ b/rhel8-branch/ko.po
@@ -1,0 +1,285 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-26 04:26-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Korean\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0}은/는 별도의 파티션이나 논리 볼륨이 있어야 하며 보안 프로파일이 설치되기 전에 파티션 레이아웃을 만들어야 합니다"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "마운트 지점 %(mount_point)s의 마운트 옵션 '%(mount_option)s'이/가 추가되었습니다"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "최소 %d자 이상으로 암호를 만들어야 합니다"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "root 암호 길이를 확인할 수 없습니다 (암호가 암호화됨)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 암호가 너무 짧습니다. 최소 %d자 이어야 합니다"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "패키지 '%s'이/가 설치할 패키지 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+"패키지 '{package}'가 제외된 패키지 목록에 추가되었지만 설치를 중단하지 않고 현재 소프트웨어 선택에서 제거할 수 없습니다."
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "패키지 '%s'이/가 제외된 패키지 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "시작시 Kdump가 비활성화됩니다"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "시작시 Kdump가 활성화됩니다"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "시작시 방화벽이 비활성화됩니다"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "시작시 방화벽이 활성화됩니다"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에 추가할 서비스 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "포트 '%s'이/가 방화벽에 추가할 포트 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "트러스트 '%s'이/가 방화벽에 추가할 트러스트 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "서비스 '%s'이/가 방화벽에서 제거할 서비스 목록에 추가되었습니다"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠 가져오기 및 로딩 중 오류가 발생했습니다.:\n"
+"%s\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"보안 컨텐츠에 대한 무결성 검사에 실패했습니다.\n"
+"설치를 중단해야 합니다. 계속 진행하시겠습니까?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "보안 정책(_S)"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "준비되어 있지 않습니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "컨텐츠 데이터를 가져오는 중"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "프로파일이 선택되지 않았습니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "사전 설치 단계의 규칙이 없습니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "잘못된 내용이 입력되었습니다. 다른 URL을 입력하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "유효하지 않거나 지원되지 않는 컨텐츠 URL입니다. 다른 URL을 입력하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "컨텐츠를 가져오지 못했습니다. 다른 URL을 입력하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "컨텐츠를 가져오는 중 네트워크 오류가 발생했습니다. 네트워크가 제대로 작동하는지 확인하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "컨텐츠 무결성 검사에 실패했습니다. 컨텐츠를 사용할 수 없습니다."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "컨텐츠 (%s)을/를 가져오지 못했습니다. 다른 URL을 입력하십시오."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID '%s'이/가 프로파일에 정의되어 있지 않습니다. 다른 프로파일을 선택하십시오"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "보안 정책을 적용하지 않음"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "데이터 스트림 컨텐츠를 입력하거나 다음 URL을 아카이브하십시오:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "내용이 없습니다. 데이터 스트림 컨텐츠를 입력하거나 또는 다음 URL을 아카이브하십시오:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "컨텐츠 오류 가져오기 및 로딩 오류"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "컨텐츠를 찾을 수 없음"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "설정 오류가 감지되었습니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "경고가 표시되었습니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "모든 것이 정상입니다"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "유효하지 않거나 지원되지 않는 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "컨텐츠 가져오는 중..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "보안 정책 "
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "컨텐츠 변경(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "보안 정책 적용:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "데이터 스트림:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "검사 목록:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "프로파일 선택:"
+
+# auto translated by TM merge from project: RHOSP Director Installation and
+# Usage , version: 11-Korean, DocId: master
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "프로파일"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "선택됨"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "프로파일 선택(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "완료된 변경사항 또는 필요한 변경사항:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "SCAP 보안 가이드 사용(_U)"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "가져오기(_F)"

--- a/rhel8-branch/oscap-anaconda-addon.pot
+++ b/rhel8-branch/oscap-anaconda-addon.pot
@@ -1,0 +1,279 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-27 15:51+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile, "
+"please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr ""
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr ""
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr ""
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr ""
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr ""
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr ""
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr ""

--- a/rhel8-branch/pl.po
+++ b/rhel8-branch/pl.po
@@ -1,0 +1,321 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Bartosz Sapijaszko <bartosz@sapek.net>, 2002
+# dcantrel <dcantrell@redhat.com>, 2011
+# Dimitris Glezos <glezos@indifex.com>, 2011
+# Dimitris Glezos <glezos@transifex.com>, 2011
+# Jacek Smyda <smyda@posexperts.com.pl>, 1998
+# Leszek Matok <lam@lac.pl>, 2004
+# Pawel Szopinski <pawel@szopinski.co.uk>, 2004
+# Piotr Drąg <piotrdrag@gmail.com>, 2014
+# Radosław Zawartko <radzaw@radzaw.one.pl>, 2004
+# sonyam <sonyam@tlen.pl>, 2004
+# Stanisław Małolepszy <smalolepszy@aviary.pl>, 2006
+# Tom Berner <tom@lodz.pl>, 2005
+# Tom Berner <tom@man.lodz.pl>, 2004
+# Wojciech Kapusta <wojciech@aviary.pl>, 2006
+# Piotr Drąg <piotrdrag@gmail.com>, 2015. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2017. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2018. #zanata
+# Piotr Drąg <piotrdrag@gmail.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-27 05:21-0400\n"
+"Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
+"Language-Team: Polish (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pl/)\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} musi być na oddzielnej partycji lub woluminie logicznym i musi być "
+"utworzone w układzie partycjonowania, zanim można przeprowadzić instalację "
+"za pomocą profilu bezpieczeństwa"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"dodano opcję montowania „%(mount_option)s” dla punktu montowania "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "proszę się upewnić, że tworzone hasło ma co najmniej %d znaków"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "nie można sprawdzić długości hasła roota (hasło jest zaszyfrowane)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"hasło roota jest za krótkie, wymagane jest dłuższe z co najmniej %d znakami"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "dodano pakiet „%s” do listy pakietów do zainstalowania"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+"pakiet „{package}” został dodany do listy wykluczonych pakietów, ale nie "
+"może zostać usunięty z obecnego wyboru oprogramowania bez uszkodzenia "
+"instalacji."
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "dodano pakiet „%s” do listy wykluczonych pakietów"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump będzie wyłączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump będzie włączone podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Zapora sieciowa będzie wyłączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Zapora sieciowa będzie włączona podczas uruchamiania"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "dodano usługę „%s” do listy usług do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "dodano port „%s” do listy portów do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "dodano zaufanie „%s” do listy zaufań do dodania do zapory sieciowej"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "dodano usługę „%s” do listy usług do usunięcia z zapory sieciowej"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Wystąpił błąd podczas pobierania i wczytywania treści bezpieczeństwa:\n"
+"%s\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Sprawdzenie spójności treści bezpieczeństwa się nie powiodło.\n"
+"Instalacja powinna zostać przerwana. Kontynuować mimo to?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Zasady bezpieczeństwa"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Niegotowe"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Pobieranie danych treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Nie wybrano profilu"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Brak reguł dla fazy przedinstalacyjnej"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Podano nieprawidłową treść. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Nieprawidłowy lub nieobsługiwany adres URL treści, proszę wybrać inny."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Pobranie treści się nie powiodło. Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Wystąpił błąd sieci podczas pobierania danych. Proszę sprawdzić, czy sieć "
+"została ustawiona i działa poprawnie."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Sprawdzenie integralności treści się nie powiodło. Nie można użyć treści."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Wydobycie treści się nie powiodło (%s). Proszę podać inny adres URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"W treści nie określono profilu o identyfikatorze „%s”. Proszę wybrać inny "
+"profil"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Bez zastosowywania zasad bezpieczeństwa"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+" albo podać treść strumienia danych lub podać adres URL archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nie odnaleziono treści. Proszę podać treść strumienia danych lub adres URL "
+"archiwum poniżej:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Błąd podczas pobierania i wczytywania treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Nie odnaleziono treści"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Wykryto błędną konfigurację"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Pojawiły się ostrzeżenia"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Wszystko jest w porządku"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Nieprawidłowy lub nieobsługiwany adres URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Pobieranie treści…"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLITYKA BEZPIECZEŃSTWA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Zmień treść"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Zastosowanie zasad bezpieczeństwa:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Strumień danych:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Lista do sprawdzenia:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Proszę wybrać profil poniżej:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Wybrane"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Wybierz profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Wprowadzone zmiany i zmiany, które muszą zostać wprowadzone:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Użycie przewodnika bezpieczeństwa SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Pobierz"

--- a/rhel8-branch/pt.po
+++ b/rhel8-branch/pt.po
@@ -1,0 +1,276 @@
+# Manuela Silva <mmsrs@sky.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2015-09-12 01:40-0400\n"
+"Last-Translator: Manuela Silva <mmsrs@sky.com>\n"
+"Language-Team: Portuguese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "A obter dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr ""
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Erro ao obter e carregar o conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Detetada má configuração"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Está tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "O obter o conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Alterar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr ""
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr ""
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr ""
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr ""
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr ""
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr ""
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr ""
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr ""
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr ""

--- a/rhel8-branch/pt_BR.po
+++ b/rhel8-branch/pt_BR.po
@@ -1,0 +1,314 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Marcelo Barbosa <firemanxbr@fedoraproject.org>, 2014
+# Marco Aurélio Krause <ouesten@me.com>, 2016. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-30 10:52-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: Portuguese (Brazil) (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/pt_BR/)\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} deve estar em uma partição separada ou em um volume lógico e deve ser "
+"criado no layout de particionamento antes que a instalação possa ocorrer com"
+" um perfil de segurança"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"opção de montagem '%(mount_option)s' adicionado para o ponto de montagem "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr ""
+"certifique-se de criar uma senha com comprimento mínimo de %d caracteres"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr ""
+"Não é possível verificar o comprimento da senha do root (senha "
+"criptografada)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"A senha root é muito curta, uma mais longa com pelo menos %d caracteres são "
+"obrigatórios"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "pacote '%s' foi adicionado à lista de pacotes a serem instalados"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "pacote '%s' foi adicionado a lista de pacotes a serem excluídos"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "O Kdump será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "O Kdump será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Firewall será desativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Firewall será ativado na inicialização"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem adicionados ao "
+"firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"port '%s'foi adicionado à lista de portas a serem adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"Confiar em '%s'foi adicionado à lista de relações de confiança a serem "
+"adicionadas ao firewall"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"serviço '%s'foi adicionado à lista de serviços a serem removidos do firewall"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ocorreu um erro ao buscar e carregar o conteúdo de segurança:\n"
+"%s\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"A verificação de integridade do conteúdo de segurança falhou.\n"
+"A instalação deve ser interrompida. Deseja continuar assim mesmo?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Política de Segurança "
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Ainda não esta pronto"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Buscando dados de conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Nenhum perfil selecionado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Não há regras para a fase de pré-instalação"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Conteúdo fornecido é inválido. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"URL do conteúdo inválido ou não suportado, entre com um outro diferente."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Falha ao buscar conteúdo. Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Foi encontrado um erro na rede ao buscar dados. Verifique se a rede está "
+"configurada e funcionando."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"A verificação de integridade do conteúdo falhou. Não é possível usar o "
+"conteúdo."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Falha ao extrair o conteúdo (%s). Digite uma URL diferente, por favor."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Perfil com ID '%s' não definido no conteúdo. Selecione um perfil diferente, "
+"por favor"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Não aplicar a política de segurança"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "ou inserir conteúdo de fluxo de dados ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Nenhum conteúdo encontrado. Por favor entre com conteúdo de fluxo de dados "
+"ou arquivo de URL abaixo:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Erro ao buscar e carregar o conteúdo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Nenhum conteúdo encontrado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Misconfiguration detectado"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Advertências surgidas"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Tudo bem"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "URL inválida ou não suportada"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Buscando conteúdo..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "POLÍTICA DE SEGURANÇA"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Mudar conteúdo"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Aplicar política de segurança:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Fluxo de dados:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklist:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Escolha o perfil abaixo:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Perfil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Selecionado"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Selecione o perfil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "As alterações que foram feitas ou precisam ser feitas:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Use SCAP Segurança Guia"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Buscar"

--- a/rhel8-branch/ru.po
+++ b/rhel8-branch/ru.po
@@ -1,0 +1,302 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-27 03:32-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} должен быть на отдельном разделе или логическом томе и должен быть "
+"создан в макете разбиения до того, как установка может произойти с профилем "
+"безопасности"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"mount option '%(mount_option)s'добавлен для точки монтирования "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "не забудьте создать пароль с минимальной длиной %d персонажи"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "не удается проверить длину пароля root (пароль зашифрован)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"пароль root слишком короткий, более длинный с по крайней мере %d требуется "
+"персонаж"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s'добавлен в список установленных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s'добавлен в список исключенных пакетов"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Брандмауэр будет отключен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Брандмауэр будет включен при запуске"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"порт '%s'добавлен в список портов, которые будут добавлены в брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"доверие \"%s'добавлен в список доверенностей, которые будут добавлены в "
+"брандмауэр"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"оказание услуг '%s'добавлен в список служб, которые необходимо удалить из "
+"брандмауэра"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ошибка получения и загрузки содержимого безопасности:%sУстановка должна быть"
+" прервана. Вы все равно хотите продолжить?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Не удалось проверить целостность содержимого безопасности. Установка должна "
+"быть прервана. Вы все равно хотите продолжить?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Политика безопасности"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Не готов"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Получение данных контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Не выбран профиль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Нет правил для этапа предварительной установки"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Недопустимый контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Неверный или неподдерживаемый URL-адрес контента, введите другой."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не удалось получить контент. Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Ошибка сети при сборе данных. Убедитесь, что сеть настроена и работает."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Не удалось проверить целостность содержимого. Невозможно использовать "
+"контент."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr ""
+"Не удалось извлечь контент (%s). Введите другой URL-адрес, пожалуйста."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профиль с идентификатором '%s'не определено в контенте. Выберите другой "
+"профиль, пожалуйста"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Не применять политику безопасности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr " или введите содержимое потока данных или URL-адрес архива ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Контент не найден. Введите содержимое потока данных или URL-адрес архива "
+"ниже:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Ошибка получения и загрузки содержимого"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Не найдено ни одного контента"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Обнаружено несоответствие"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Появились предупреждения"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Все в порядке"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Недействительный или неподдерживаемый URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Получение контента ..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПОЛИТИКА БЕЗОПАСНОСТИ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Изменить контент"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Применение политики безопасности:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Поток данных:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Контрольный список:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Выберите профиль ниже:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профиль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "выбранный"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Выбрать профиль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Изменения, которые были сделаны или должны быть выполнены:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Используйте руководство по безопасности SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Получить"

--- a/rhel8-branch/sr.po
+++ b/rhel8-branch/sr.po
@@ -1,0 +1,286 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+# Momcilo Medic <medicmomcilo@gmail.com>, 2014
+# Momcilo Medic <medicmomcilo@gmail.com>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2015-04-18 01:39-0400\n"
+"Last-Translator: Momcilo Medic <medicmomcilo@gmail.com>\n"
+"Language-Team: Serbian (http://www.transifex.com/projects/p/oscap-anaconda-addon/language/sr/)\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"прикључна опција '%(mount_option)s' додата за прикључну тачку "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "изаберите шифру од најмање %d карактера"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "немогуће проверити дужину root шифре (шифра је криптована)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "пакет '%s' је додат на листу пакета за инсталацију"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "пакет '%s' је додат на листу искључених пакета"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Није спремно"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Преузимање података о садржају"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Није изабран профил"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Нема правила за пред-инсталациону фазу"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Неисправан садржај пружен. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Неуспешно преузимање садржаја. Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Неуспешно извлачење садржаја (%s). Унесите други URL, молим."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Не примењујем полису безбедности"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "или унесите садржајни или архивски URL за stream података испод:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Садржај није пронађен. Молим унесите садржајни или архивски URL за stream "
+"података:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr ""
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Садржај није пронађен"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Погрешно подешавање откривено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Упозорења су се појавила"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Све је у реду"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Неисправан или неподржан URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Преузимање садржаја..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "БЕЗБЕДНОСНИ МОДЕЛ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Промена садржаја"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Примени сигурносну политику:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Stream података:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Листа:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Изаберите профил:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профил"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Изабрано"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Изаберите профил"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Промене које су урађене или требају да се ураде:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Користи SCAP сигурносни водич"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Преузми"

--- a/rhel8-branch/sv.po
+++ b/rhel8-branch/sv.po
@@ -1,0 +1,301 @@
+# Göran Uddeborg <goeran@uddeborg.se>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-09-21 05:31-0400\n"
+"Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+"{0} måste finnas på en separat partition eller logisk volym och måste skapas"
+" i partitioneringslayouten före installationen kan ske med en "
+"säkerhetsprofil"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"monteringsflaggan ”%(mount_option)s” tillagd för monteringspunkten "
+"%(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "se till att skapa lösenord med minsta längd av %d tecken"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "kan inte kontrollera root-lösenordets längd (lösenordet är krypterat)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+"root-lösenordet är för kort, ett längre med åtminstone %d tecken krävs"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "paketet ”%s” har lagts till till listan av paket att installeras"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "paketet ”%s” har lagts till till listan av uteslutna paket"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump kommer avaktiveras vid uppstart"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump kommer aktiveras vid uppstart"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "Brandväggen kommer avaktiveras vid uppstart"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "Brandväggen kommer aktiveras vid uppstart"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+"tjänsten ”%s”har lagts till till listan över tjänster att läggas till i "
+"brandväggen"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+"porten ”%s”har lagts till till listan över portar att läggas till i "
+"brandväggen"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+"förtroendet ”%s”har lagts till till listan över förtoenden att läggas till i"
+" brandväggen"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+"tjänsten ”%s”har lagts till till listan över tjänster att tas bort från "
+"brandväggen"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Ett fel uppstod när säkerhetskontexten hämtades och laddades:\n"
+"%s\n"
+"Installationen bör avbrytas.  Önskar du ändå fortsätta?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Integritetskontrollen av säkerhetsinnehållet misslyckades.\n"
+"Installationen bör avbrytas.  Önskar du fortsätta ändå?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "_Säkerhetspolicy"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Inte redo"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Hämtar innehållsdata"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Ingen profil vald"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Inga regler för förinstallationsfasen"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Felaktigt innehåll tillhandahölls.  Ange en annan URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "Felaktig eller ej stödd innehålls-URL, ange en annan."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Misslyckades att hämta innehåll.  Ange en annan URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Nätverksfel uppstod när data hämtades.  Kontrollera att nätverket är uppsatt"
+" och fungerar."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr ""
+"Integritetskontrollen av innehållet misslyckades.  Kan inte använda "
+"innehållet."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Misslyckades att extrahera innehållet (%s).  Ange en annan URL."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Profilen med ID ”%s” är inte definierad i innehållet.  Välj en annan profil."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Tillämpar inte säkerhetspolicyn"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "eller ange ett dataströmsinnehåll eller en arkiv-URL nedan:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Inget innehåll hittat.  Ange dataströmsinnehåll eller arkiv-URL nedan:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Fel när innehåll hämtades och laddades"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Inget innehåll hittat"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Felkonfiguration upptäckt"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Varningar uppstod"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Allting okej"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Felaktig eller ej stödd URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Hämtar innehåll …"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "SÄKERHETSPOLICY"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "_Ändra innehåll"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Tillämpa säkerhetspolicy:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Dataström:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Checklista:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Välj profil nedan:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Profil"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Vald"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Välj profil"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Ändringar som gjordes eller behöver göras:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_Använd SCAP säkerhetsguide"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Hämta"

--- a/rhel8-branch/uk.po
+++ b/rhel8-branch/uk.po
@@ -1,0 +1,291 @@
+# Yuri Chornoivan <yurchor@ukr.net>, 2015.
+# Yuri Chornoivan <yurchor@ukr.net>, 2015. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2015-08-31 03:22-0400\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr ""
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr ""
+"для точки монтування %(mount_point)s додано параметр монтування "
+"«%(mount_option)s»"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "довжина пароля має бути не меншою за %d символів"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "не вдалося перевірити довжину пароля root (пароль зашифровано)"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "до списку встановлюваних пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "до списку виключених пакунків додано пакунок «%s»"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr ""
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Під час отримання та завантаження даних захисту сталася помилка:\n"
+"%s\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"Дані захисту не пройшли перевірку на цілісність.\n"
+"Встановлення слід перервати. Хочете продовжити його попри це?"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr ""
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "Неготовий"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "Отримуємо дані"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "Не вибрано жодного профілю"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "Правил для кроку перед встановленням немає"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "Надано некоректні дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr ""
+"Некоректна або непідтримувана адреса даних. Будь ласка, введіть якусь іншу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "Не вдалося отримати дані. Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr ""
+"Під час спроби отримання даних сталася помилка, пов’язана із мережею. Будь "
+"ласка, перевірте, чи правильно налаштовано з’єднання, та чи є воно "
+"працездатним."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "Дані не пройшли перевірку на цілісність. Їхнє використання неможливе."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "Не вдалося видобути дані (%s). Будь ласка, вкажіть іншу адресу."
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr ""
+"Профіль з ідентифікатором «%s» у даних не визначено. Виберіть, будь ласка, "
+"інший профіль"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "Не застосовуємо правил захисту"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr " або вкажіть адресу потоку даних чи архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr ""
+"Даних не знайдено. Будь ласка, вкажіть адресу потоку даних або архіву:"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "Помилка під час спроби отримання та завантаження даних"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "Даних не знайдено"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "Виявлено помилки у налаштуваннях"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "Отримано попередження"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "Все гаразд"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "Некоректна або непідтримувана адреса"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "Отримуємо дані…"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "ПРАВИЛА ЗАХИСТУ"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "З_міна даних"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "Застосувати правило захисту:"
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "Потік даних:"
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "Список для перевірки:"
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "Виберіть профіль:"
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "Профіль"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "Позначене"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "_Вибрати профіль"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "Зміни, які внесено або має бути внесено:"
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "Ви_користати настанови із захисту SCAP"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "_Отримати"

--- a/rhel8-branch/zh_CN.po
+++ b/rhel8-branch/zh_CN.po
@@ -1,0 +1,282 @@
+# Ludek Janda <ljanda@redhat.com>, 2018. #zanata
+# Ludek Janda <ljanda@redhat.com>, 2020. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2020-06-26 04:26-0400\n"
+"Last-Translator: Copied by Zanata <copied-by-zanata@zanata.org>\n"
+"Language-Team: Chinese (Simplified)\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必须在一个独立的分区或逻辑卷上，并需要在带有安全档案的安装进行前，在分区布局中创建"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "为挂载点 %(mount_point)s 添加的挂载选项 '%(mount_option)s'"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "确保创建的密码长度最少为 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "无法检查 root 密码的长度（密码已加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root 密码太短，它需要最少包括 %d 个字符"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "软件包 '%s' 已被添加到要被安装的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr "软件包 '{package}' 已被添加到排除的软件包列表中，但在不破坏安装的情况下，无法从当前的软件选择中删除。"
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "软件包 '%s' 已被添加到排除的软件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump 将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump 将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "防火墙将在启动时被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "防火墙将在启动时被启用"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要加到防火墙的服务列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "端口 '%s' 已被添加到要加到防火墙的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任 '%s' 已被添加到要加到防火墙的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服务 '%s' 已被添加到要从防火墙删除的服务列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"在获取和加载安全内容时出错：\n"
+"%s\n"
+"安装应该被终止。您希望继续吗？"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr ""
+"对安全内容的完整性检查失败。\n"
+"安装应该被终止。您希望继续吗？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "安全策略（_S）"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "未就绪"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "获取内容数据"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "没有选择 profile"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "没有预安装阶段的规则"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供无效的内容。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "无效或不支持的内容 URL，请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "获取内容失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "在获取数据时出现网络错误。请检查网络是否正常。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "内容的完整性检查失败。不能使用这个内容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "提取内容 (%s) 失败。请输入一个不同的 URL。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "ID 为 '%s' 的档案没有在内容中定义。请选择一个不同的档案"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "没有应用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr "或输入数据流内容或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "没有找到内容。请输入数据流或归档 URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "获取并加载内容错误"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "没有找到内容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "发现错误配置"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "出现的警告"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "一切正常"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "无效或不支持的 URL"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "获取内容..."
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全策略"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "修改内容(_C)"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "应用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "数据流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "检查列表："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "选择档案："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "档案"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "选择"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "选择档案(_S)"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的改变："
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "使用 SCAP 安全指南(_U)"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "获取(_F)"

--- a/rhel8-branch/zh_TW.po
+++ b/rhel8-branch/zh_TW.po
@@ -1,0 +1,276 @@
+# Ludek Janda <ljanda@redhat.com>, 2019. #zanata
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-09 17:35+0200\n"
+"PO-Revision-Date: 2019-08-30 10:56-0400\n"
+"Last-Translator: Ludek Janda <ljanda@redhat.com>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Zanata 4.6.2\n"
+
+#: ../org_fedora_oscap/rule_handling.py:409
+#, python-brace-format
+msgid ""
+"{0} must be on a separate partition or logical volume and has to be created "
+"in the partitioning layout before installation can occur with a security "
+"profile"
+msgstr "{0} 必須位於單獨的分區或邏輯卷上，並且必須在分區佈局中創建，然後才能使用安全配置文件進行安裝"
+
+#. template for the message
+#: ../org_fedora_oscap/rule_handling.py:420
+#, python-format
+msgid ""
+"mount option '%(mount_option)s' added for the mount point %(mount_point)s"
+msgstr "掛載選項'%(mount_option)s'為掛載點添加了 %(mount_point)s"
+
+#. root password was not set
+#: ../org_fedora_oscap/rule_handling.py:529
+#, python-format
+msgid "make sure to create password with minimal length of %d characters"
+msgstr "確保以最小的長度創建密碼 %d 人物"
+
+#: ../org_fedora_oscap/rule_handling.py:536
+msgid "cannot check root password length (password is crypted)"
+msgstr "無法檢查root密碼長度（密碼被加密）"
+
+#. too short
+#: ../org_fedora_oscap/rule_handling.py:542
+#, python-format
+msgid ""
+"root password is too short, a longer one with at least %d characters is "
+"required"
+msgstr "root密碼太短，至少有一個 %d 字符是必需的"
+
+#: ../org_fedora_oscap/rule_handling.py:660
+#: ../org_fedora_oscap/rule_handling.py:675
+#, python-format
+msgid "package '%s' has been added to the list of to be installed packages"
+msgstr "包'%s'已添加到要安裝的軟件包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:685
+#, python-brace-format
+msgid ""
+"package '{package}' has been added to the list of excluded packages, but it "
+"can't be removed from the current software selection without breaking the "
+"installation."
+msgstr ""
+
+#: ../org_fedora_oscap/rule_handling.py:692
+#: ../org_fedora_oscap/rule_handling.py:707
+#, python-format
+msgid "package '%s' has been added to the list of excluded packages"
+msgstr "包'%s'已添加到已排除的包列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:808
+msgid "Kdump will be disabled on startup"
+msgstr "Kdump將在啟動時被禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:810
+msgid "Kdump will be enabled on startup"
+msgstr "Kdump將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:963
+msgid "Firewall will be disabled on startup"
+msgstr "防火牆將在啟動時禁用"
+
+#: ../org_fedora_oscap/rule_handling.py:970
+msgid "Firewall will be enabled on startup"
+msgstr "防火牆將在啟動時啟用"
+
+#: ../org_fedora_oscap/rule_handling.py:978
+#: ../org_fedora_oscap/rule_handling.py:1017
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be added to the "
+"firewall"
+msgstr "服務'%s'已添加到要添加到防火牆的服務列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:985
+#: ../org_fedora_oscap/rule_handling.py:1030
+#, python-format
+msgid ""
+"port '%s' has been added to the list of ports to be added to the firewall"
+msgstr "港口 '%s'已被添加到要添加到防火牆的端口列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:992
+#: ../org_fedora_oscap/rule_handling.py:1043
+#, python-format
+msgid ""
+"trust '%s' has been added to the list of trusts to be added to the firewall"
+msgstr "信任'%s'已被添加到要添加到防火牆的信任列表中"
+
+#: ../org_fedora_oscap/rule_handling.py:1055
+#: ../org_fedora_oscap/rule_handling.py:1070
+#, python-format
+msgid ""
+"service '%s' has been added to the list of services to be removed from the "
+"firewall"
+msgstr "服務'%s'已被添加到要從防火牆中刪除的服務列表中"
+
+#: ../org_fedora_oscap/ks/oscap.py:418
+#, python-format
+msgid ""
+"There was an error fetching and loading the security content:\n"
+"%s\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "獲取和加載安全內容時出錯：%s安裝應該中止。你想繼續嗎？"
+
+#: ../org_fedora_oscap/ks/oscap.py:447
+msgid ""
+"The integrity check of the security content failed.\n"
+"The installation should be aborted. Do you wish to continue anyway?"
+msgstr "安全內容的完整性檢查失敗。安裝應該中止。你想繼續嗎？"
+
+#. title of the spoke (will be displayed on the hub)
+#: ../org_fedora_oscap/gui/spokes/oscap.py:198
+msgid "_Security Policy"
+msgstr "安全政策（_S）"
+
+#. the first status provided
+#: ../org_fedora_oscap/gui/spokes/oscap.py:226
+msgid "Not ready"
+msgstr "沒有準備好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:374
+msgid "Fetching content data"
+msgstr "獲取內容數據"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:641
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1056
+msgid "No profile selected"
+msgstr "沒有選擇個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:646
+msgid "No rules for the pre-installation phase"
+msgstr "沒有預安裝階段的規則"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:798
+msgid "Invalid content provided. Enter a different URL, please."
+msgstr "提供的內容無效。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:806
+msgid "Invalid or unsupported content URL, please enter a different one."
+msgstr "無效或不受支持的內容網址，請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:814
+msgid "Failed to fetch content. Enter a different URL, please."
+msgstr "無法獲取內容。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:822
+msgid ""
+"Network error encountered when fetching data. Please check that network is "
+"setup and working."
+msgstr "獲取數據時遇到網絡錯誤。請檢查網絡是否已設置並正常運行。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:831
+msgid "The integrity check of the content failed. Cannot use the content."
+msgstr "內容的完整性檢查失敗。無法使用內容。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:839
+#, python-format
+msgid "Failed to extract content (%s). Enter a different URL, please."
+msgstr "無法提取內容（%s）。請輸入其他網址。"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:857
+#, python-format
+msgid ""
+"Profile with ID '%s' not defined in the content. Select a different profile,"
+" please"
+msgstr "帶ID的個人資料'%s'沒有在內容中定義。請選擇其他個人資料"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:873
+msgid "Not applying security policy"
+msgstr "不應用安全策略"
+
+#. TRANSLATORS: the other choice if SCAP Security Guide is also
+#. available
+#: ../org_fedora_oscap/gui/spokes/oscap.py:904
+msgid " or enter data stream content or archive URL below:"
+msgstr " 或輸入以下數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:908 tmp/oscap.glade.h:12
+msgid ""
+"No content found. Please enter data stream content or archive URL below:"
+msgstr "找不到任何內容。請在下面輸入數據流內容或存檔URL："
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1046
+msgid "Error fetching and loading content"
+msgstr "獲取和加載內容時出錯"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1053
+msgid "No content found"
+msgstr "找不到任何內容"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1064
+msgid "Misconfiguration detected"
+msgstr "檢測到配置錯誤"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1070
+msgid "Warnings appeared"
+msgstr "警告出現了"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1072
+msgid "Everything okay"
+msgstr "一切都好"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1148
+msgid "Invalid or unsupported URL"
+msgstr "網址無效或不受支持"
+
+#: ../org_fedora_oscap/gui/spokes/oscap.py:1154 tmp/oscap.glade.h:14
+msgid "Fetching content..."
+msgstr "獲取內容......"
+
+#: tmp/oscap.glade.h:1
+msgid "SECURITY POLICY"
+msgstr "安全政策"
+
+#: tmp/oscap.glade.h:2
+msgid "_Change content"
+msgstr "改變內容（_C）"
+
+#: tmp/oscap.glade.h:3
+msgid "Apply security policy:"
+msgstr "應用安全策略："
+
+#: tmp/oscap.glade.h:4
+msgid "Data stream:"
+msgstr "數據流："
+
+#: tmp/oscap.glade.h:5
+msgid "Checklist:"
+msgstr "清單："
+
+#: tmp/oscap.glade.h:6
+msgid "Choose profile below:"
+msgstr "選擇以下資料："
+
+#: tmp/oscap.glade.h:7
+msgid "Profile"
+msgstr "輪廓"
+
+#: tmp/oscap.glade.h:8
+msgid "Selected"
+msgstr "選"
+
+#: tmp/oscap.glade.h:9
+msgid "_Select profile"
+msgstr "選擇個人資料（_S）"
+
+#: tmp/oscap.glade.h:10
+msgid "Changes that were done or need to be done:"
+msgstr "已完成或需要完成的更改："
+
+#: tmp/oscap.glade.h:11
+msgid "_Use SCAP Security Guide"
+msgstr "_使用SCAP安全指南（_U）"
+
+#: tmp/oscap.glade.h:13
+msgid "_Fetch"
+msgstr "取（_F）"


### PR DESCRIPTION
Zanata is now read-only, and the newly-added directories `master`, rhel7-branch` and `rhel8-branch` mirror Zanata branches (po) and respective upstream source (pot) files.

This PR aims to port all non-empty translations, and it translates Zanata "branches" into folders.

For reference, see the [analogous Anaconda repository](https://github.com/rhinstaller/anaconda-l10n), and the related Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1785030